### PR TITLE
Correction history indexed by pawn hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.16)
 project(integral)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -27,8 +27,8 @@ elseif(BUILD_NATIVE)
 endif()
 
 # Set debug and release specific flags
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -fomit-frame-pointer -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -DNDEBUG")
+set(CMAKE_CXX_FLAGS_RELEASE "-pthread -O3 -fomit-frame-pointer -DNDEBUG")
+set(CMAKE_CXX_FLAGS_DEBUG "-pthread -O0 -DNDEBUG")
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Default compiler settings
 CC=gcc
-CXX=g++
+CXX=clang++
 
 # Detect the operating system
 ifeq ($(OS),Windows_NT)

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -83,6 +83,7 @@ struct BoardState {
         fifty_moves_clock(0),
         en_passant(std::nullopt),
         zobrist_key(0ULL),
+        pawn_key(0ULL),
         checkers(0ULL),
         pinned(0ULL),
         phase(0) {
@@ -107,6 +108,10 @@ struct BoardState {
     // Insert the piece to the hash
     if constexpr (update_key) {
       zobrist_key ^= zobrist::HashSquare(square, *this, color, piece_type);
+
+      if (piece_type == PieceType::kPawn) {
+        pawn_key ^= zobrist::HashSquare(square, *this, color, PieceType::kPawn);
+      }
     }
   }
 
@@ -117,6 +122,10 @@ struct BoardState {
     // Remove the piece from the hash
     if constexpr (update_key) {
       zobrist_key ^= zobrist::HashSquare(square, *this, color, piece_type);
+
+      if (piece_type == PieceType::kPawn) {
+        pawn_key ^= zobrist::HashSquare(square, *this, color, PieceType::kPawn);
+      }
     }
 
     // Clear the piece from the bitboards
@@ -222,7 +231,7 @@ struct BoardState {
     return checkers != 0;
   }
 
-  std::array<BitBoard, PieceType::kNumTypes> piece_bbs;
+  std::array<BitBoard, kNumPieceTypes> piece_bbs;
   std::array<BitBoard, 2> side_bbs;
   std::array<PieceType, kSquareCount> piece_on_square;
   Color turn;
@@ -230,6 +239,7 @@ struct BoardState {
   std::optional<Square> en_passant;
   CastleRights castle_rights;
   U64 zobrist_key;
+  U64 pawn_key;
   BitBoard checkers;
   BitBoard pinned;
   SideTable<ScorePair> piece_scores;

--- a/src/chess/fen.cc
+++ b/src/chess/fen.cc
@@ -3,7 +3,7 @@
 namespace fen {
 
 // clang-format off
-constexpr std::array<std::array<char, PieceType::kNumTypes + 1>, 2> kPieceToChar = {{
+constexpr std::array<std::array<char, kNumPieceTypes + 1>, 2> kPieceToChar = {{
   {'p', 'n', 'b', 'r', 'q', 'k', 'x'},
   {'P', 'N', 'B', 'R', 'Q', 'K', 'x'}
 }};
@@ -70,8 +70,6 @@ BoardState StringToBoard(std::string_view fen_str) {
   }
 
   stream >> state.fifty_moves_clock;
-
-  state.zobrist_key = zobrist::GenerateKey(state);
 
   return state;
 }

--- a/src/engine/evaluation/evaluation.cc
+++ b/src/engine/evaluation/evaluation.cc
@@ -8,7 +8,7 @@ namespace masks {
 
 constexpr SideTable<SquareTable<BitBoard>> GenerateForwardFiles() {
   SideTable<SquareTable<BitBoard>> forward_file;
-  for (Square square = 0; square < Squares::kSquareCount; square++) {
+  for (Square square = 0; square < kSquareCount; square++) {
     forward_file[Color::kWhite][square] =
         ForwardFileMask(Color::kWhite, square);
     forward_file[Color::kBlack][square] =
@@ -22,7 +22,7 @@ constexpr SideTable<SquareTable<BitBoard>> forward_file =
 
 constexpr SideTable<SquareTable<BitBoard>> GenerateForwardFileAdjacent() {
   SideTable<SquareTable<BitBoard>> forward_file_adjacent;
-  for (Square square = 0; square < Squares::kSquareCount; square++) {
+  for (Square square = 0; square < kSquareCount; square++) {
     const BitBoard white_forward = forward_file[Color::kWhite][square];
     forward_file_adjacent[Color::kWhite][square] =
         Shift<Direction::kWest>(white_forward) | white_forward |
@@ -41,7 +41,7 @@ constexpr SideTable<SquareTable<BitBoard>> forward_file_adjacent =
 
 constexpr SquareTable<BitBoard> GenerateFiles() {
   SquareTable<BitBoard> files;
-  for (Square square = 0; square < Squares::kSquareCount; square++) {
+  for (Square square = 0; square < kSquareCount; square++) {
     files[square] = kFileMasks[File(square)];
   }
   return files;
@@ -51,7 +51,7 @@ constexpr SquareTable<BitBoard> files = GenerateFiles();
 
 constexpr SquareTable<BitBoard> GenerateAdjacentFiles() {
   SquareTable<BitBoard> adjacent_files;
-  for (Square square = 0; square < Squares::kSquareCount; square++) {
+  for (Square square = 0; square < kSquareCount; square++) {
     adjacent_files[square] = Shift<Direction::kWest>(files[square]) |
                              Shift<Direction::kEast>(files[square]);
   }

--- a/src/engine/evaluation/evaluation.h
+++ b/src/engine/evaluation/evaluation.h
@@ -6,7 +6,7 @@
 
 namespace eval {
 
-constexpr std::array<Score, PieceType::kNumTypes + 1> kSEEPieceScores = {
+constexpr std::array<Score, kNumPieceTypes + 1> kSEEPieceScores = {
     100,  // Pawn
     300,  // Knight
     300,  // Bishop

--- a/src/engine/evaluation/evaluation_terms.h
+++ b/src/engine/evaluation/evaluation_terms.h
@@ -7,11 +7,11 @@ namespace eval {
 
 // clang-format off
 template <typename T>
-using PieceValueTable = std::array<T, PieceType::kNumTypes>;
+using PieceValueTable = std::array<T, kNumPieceTypes>;
 
 template <typename T>
 using PieceSquareTable = std::array<std::array<T, kSquareCount>,
-                                    PieceType::kNumTypes>;
+                                    kNumPieceTypes>;
 
 template <typename T>
 using KnightMobilityTable = std::array<T, 9>;
@@ -165,7 +165,7 @@ constexpr std::array<ScorePair, 21> kPawnStormTable = {
 constexpr ScorePair kBishopPairBonus = Pair(22, 65);
 constexpr ScorePair kTempoBonus = Pair(21, 25);
 
-constexpr std::array<int, PieceType::kNumTypes> kPhaseIncrements = {0, 1, 1, 2, 4, 0};
+constexpr std::array<int, kNumPieceTypes> kPhaseIncrements = {0, 1, 1, 2, 4, 0};
 // clang-format on
 
 }  // namespace eval

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -12,7 +12,7 @@ constexpr int kHistoryDefaultMaxBonus = 1159;
 static int HistoryBonus(int depth,
                         int scale = kHistoryDefaultScale,
                         int max_bonus = kHistoryDefaultMaxBonus) {
-  return std::min(scale * depth, max_bonus);
+  return std::clamp(scale * depth, -max_bonus, max_bonus);
 }
 
 // Linear interpolation of the bonus and maximum score
@@ -22,6 +22,6 @@ static int ScaleBonus(I32 score,
   return bonus - score * std::abs(bonus) / gravity;
 }
 
-}
+} // namespace history
 
 #endif  // INTEGRAL_BONUS_H

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -8,12 +8,61 @@ namespace history {
 
 class CorrectionHistory {
  public:
-  explicit CorrectionHistory(const BoardState &state) : state_(state) {}
+  explicit CorrectionHistory(const BoardState &state)
+      : state_(state), table_({}) {}
 
-  void UpdateScore(SearchStackEntry *stack, MoveList &quiets);
+  static constexpr int kHistorySize = 16384;
+  static constexpr int kHistoryMaxBonus = 128;
+  static constexpr int kHistoryGravity = 512;
+
+  void UpdateScore(SearchStackEntry *stack,
+                   Score search_score,
+                   TranspositionTableEntry::Flag score_type,
+                   int depth) {
+    if (!StaticEvalWithinBounds(stack->static_eval, search_score, score_type)) {
+      return;
+    }
+
+    const Score static_eval_error = search_score - stack->static_eval;
+    const int bonus = std::clamp(static_eval_error * depth / 8,
+                                 -kHistoryGravity / 4,
+                                 kHistoryGravity / 4);
+
+    // Apply a linear dampening to the bonus as the depth increases
+    Score &score = table_[state_.turn][GetTableIndex()];
+    score += ScaleBonus(score, bonus, kHistoryGravity);
+  }
+
+  [[nodiscard]] Score CorrectedStaticEval() const {
+    const Score static_eval = eval::Evaluate(state_);
+    const Score correction = table_[state_.turn][GetTableIndex()];
+    const Score adjusted_score =
+        static_eval + (correction * std::abs(correction)) / kHistorySize;
+
+    // Ensure no static evaluations are mate scores
+    return std::clamp(adjusted_score,
+                      -kMateScore + kMaxPlyFromRoot + 1,
+                      kMateScore - kMaxPlyFromRoot - 1);
+  }
+
+ private:
+  [[nodiscard]] bool StaticEvalWithinBounds(
+      Score static_eval,
+      Score search_score,
+      TranspositionTableEntry::Flag score_type) const {
+    const bool failed_high = score_type == TranspositionTableEntry::kLowerBound;
+    const bool failed_low = score_type == TranspositionTableEntry::kUpperBound;
+    return !(failed_high && static_eval >= search_score) &&
+           !(failed_low && static_eval < search_score);
+  }
+
+  [[nodiscard]] int GetTableIndex() const {
+    return state_.pawn_key & (kHistorySize - 1);
+  }
 
  private:
   const BoardState &state_;
+  MultiArray<Score, kNumColors, kHistorySize> table_;
 };
 
 }  // namespace history

--- a/src/engine/search/history/history.h
+++ b/src/engine/search/history/history.h
@@ -18,11 +18,13 @@ class SearchHistory {
     // Reinitialize the history objects for quicker clearing
     quiet_history = std::make_unique<QuietHistory>(state_);
     continuation_history = std::make_unique<ContinuationHistory>(state_);
+    correction_history = std::make_unique<CorrectionHistory>(state_);
   }
 
  public:
   std::unique_ptr<QuietHistory> quiet_history;
   std::unique_ptr<ContinuationHistory> continuation_history;
+  std::unique_ptr<CorrectionHistory> correction_history;
 
  private:
   const BoardState &state_;

--- a/src/engine/search/history/quiet_history.h
+++ b/src/engine/search/history/quiet_history.h
@@ -18,26 +18,26 @@ class QuietHistory {
     const int bonus = HistoryBonus(depth);
 
     // Apply a linear dampening to the bonus as the depth increases
-    I32 &score = table_[turn][move.GetFrom()][move.GetTo()];
+    int &score = table_[turn][move.GetFrom()][move.GetTo()];
     score += ScaleBonus(score, bonus);
 
     // Lower the score of the quiet moves that failed to raise alpha
     for (int i = 0; i < quiets.Size(); i++) {
       const Move bad_quiet = quiets[i];
       // Apply a linear dampening to the penalty as the depth increases
-      I32 &bad_quiet_score =
+      int &bad_quiet_score =
           table_[turn][bad_quiet.GetFrom()][bad_quiet.GetTo()];
       bad_quiet_score += ScaleBonus(bad_quiet_score, -bonus);
     }
   }
 
-  [[nodiscard]] I32 GetScore(Move move) const {
+  [[nodiscard]] int GetScore(Move move) const {
     return table_[state_.turn][move.GetFrom()][move.GetTo()];
   }
 
  private:
   const BoardState &state_;
-  MultiArray<I32, kNumColors, kSquareCount, kSquareCount> table_;
+  MultiArray<int, kNumColors, kSquareCount, kSquareCount> table_;
 };
 
 }  // namespace history

--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -1,7 +1,7 @@
 #include "move_picker.h"
 
 // clang-format off
-constexpr std::array<std::array<int, PieceType::kNumTypes>, PieceType::kNumTypes> kMVVLVATable = {{
+constexpr std::array<std::array<int, kNumPieceTypes>, kNumPieceTypes> kMVVLVATable = {{
   {{10, 11, 12, 13, 14, 15}}, // victim P,    attacker K, Q, R, B, N, P
   {{20, 21, 22, 23, 24, 25}}, // victim N,    attacker K, Q, R, B, N, P
   {{30, 31, 32, 33, 34, 35}}, // victim B,    attacker K, Q, R, B, N, P

--- a/src/tuner/tuner.cc
+++ b/src/tuner/tuner.cc
@@ -17,7 +17,7 @@ constexpr double kLearningRate = 1.0;
 constexpr double kLearningDropRate = 1.00;
 constexpr int kLearningStepRate = 250;
 
-constexpr double Sigmoid(double K, double E) {
+inline double Sigmoid(double K, double E) {
   return 1.0 / (1.0 + exp(-K * E / 400.0));
 }
 
@@ -124,7 +124,7 @@ void Tuner::Tune() {
 
 void Tuner::InitBaseParameters() {
   AddArrayParameter(kPieceValues);
-  Add2DArrayParameter<PieceType::kNumTypes, kSquareCount>(kPieceSquareTable);
+  Add2DArrayParameter<kNumPieceTypes, kSquareCount>(kPieceSquareTable);
   AddArrayParameter(kKnightMobility);
   AddArrayParameter(kBishopMobility);
   AddArrayParameter(kRookMobility);
@@ -347,7 +347,7 @@ void Tuner::PrintParameters() {
   PrintArray(index, kPieceValues.size(), parameters_);
 
   fmt::print("constexpr PieceSquareTable<ScorePair> kPieceSquareTable = ");
-  Print2DArray(index, PieceType::kNumTypes, Squares::kSquareCount, parameters_);
+  Print2DArray(index, kNumPieceTypes, kSquareCount, parameters_);
 
   fmt::print("constexpr KnightMobilityTable<ScorePair> kKnightMobility = ");
   PrintArray(index, kKnightMobility.size(), parameters_);

--- a/src/utils/list.h
+++ b/src/utils/list.h
@@ -15,14 +15,6 @@ class List {
     return container_[i];
   }
 
-  inline T &Back() {
-    return container_[count_ - 1];
-  }
-
-  inline const T &At(int i) {
-    return container_[i];
-  }
-
   inline void Push(const T &object) {
     assert(count_ < length);
     container_[count_++] = object;
@@ -33,18 +25,13 @@ class List {
     container_[count_++] = std::move(object);
   }
 
-  inline void Heapify() {
-    std::make_heap(container_.begin(), container_.begin() + count_);
-  }
-
-  inline T &HeapPop() {
-    std::pop_heap(container_.begin(), container_.begin() + count_--);
-    return container_[count_];
-  }
-
   inline T &PopBack() {
     assert(count_ > 0);
     return container_[--count_];
+  }
+
+  inline T &Back() {
+    return container_[count_ - 1];
   }
 
   inline void Erase(int i) {

--- a/src/utils/types.h
+++ b/src/utils/types.h
@@ -24,7 +24,7 @@ enum PieceType : U8 {
   kQueen,
   kKing,
   kNone,
-  kNumTypes = kNone
+  kNumPieceTypes = kNone
 };
 
 enum class PromotionType : U8 {
@@ -115,7 +115,7 @@ template <typename T>
 using SideTable = std::array<T, 2>;
 
 template <typename T>
-using SquareTable = std::array<T, Squares::kSquareCount>;
+using SquareTable = std::array<T, kSquareCount>;
 
 using Score = I32;
 class ScorePair {


### PR DESCRIPTION
This patch adds the static eval correction history, as implemented in Stockfish.
When the static evaluation does not match the resulting search bound, the correction value for the current pawn structure gets adjusted to move future static evals closer to the actual search result.

STC:
```
Elo   | 11.82 +- 6.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5030 W: 1387 L: 1216 D: 2427
Penta | [122, 590, 965, 671, 167]
https://chess.aronpetkovski.com/test/641/
```

Bench: 1165913