### PR TITLE
QS Futility Pruning

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -202,7 +202,7 @@ Score Search::QuiescentSearch(Score alpha,
     alpha = std::max(alpha, best_score);
   }
 
-  const Score futility_score = best_score + 60;
+  const Score futility_score = best_score + 100;
 
   MovePicker move_picker(
       MovePickerType::kQuiescence, board_, tt_move, history_, stack);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -221,7 +221,8 @@ Score Search::QuiescentSearch(Score alpha,
     }
 
     // QS Futility Pruning:
-    if (!state.InCheck() && futility_score <= alpha && !eval::StaticExchange(move, 1, state)) {
+    if (!state.InCheck() && move.IsCapture(state) && futility_score <= alpha &&
+        !eval::StaticExchange(move, 1, state)) {
       best_score = std::max(best_score, futility_score);
       continue;
     }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -220,7 +220,8 @@ Score Search::QuiescentSearch(Score alpha,
       continue;
     }
 
-    // QS Futility Pruning:
+    // QS Futility Pruning: Prune capture moves that don't win material if the static
+    // eval is behind alpha by some margin
     if (!state.InCheck() && move.IsCapture(state) && futility_score <= alpha &&
         !eval::StaticExchange(move, 1, state)) {
       best_score = std::max(best_score, futility_score);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -187,7 +187,6 @@ Score Search::QuiescentSearch(Score alpha,
 
   int moves_seen = 0;
   Score best_score = -kMateScore + stack->ply;
-  Score futility_score = state.InCheck() ? best_score : best_score + 60;
   Move best_move = Move::NullMove();
 
   Score static_eval = kScoreNone;
@@ -205,6 +204,8 @@ Score Search::QuiescentSearch(Score alpha,
     alpha = std::max(alpha, static_eval);
   }
 
+  const Score futility_score = best_score + 60;
+
   MovePicker move_picker(
       MovePickerType::kQuiescence, board_, tt_move, history_, stack);
   while (const auto move = move_picker.Next()) {
@@ -219,6 +220,7 @@ Score Search::QuiescentSearch(Score alpha,
       continue;
     }
 
+    // QS Futility Pruning:
     if (!state.InCheck() && futility_score <= alpha && !eval::StaticExchange(move, 1, state)) {
       best_score = std::max(best_score, futility_score);
       continue;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -187,6 +187,7 @@ Score Search::QuiescentSearch(Score alpha,
 
   int moves_seen = 0;
   Score best_score = -kMateScore + stack->ply;
+  Score futility_score = state.InCheck() ? best_score : best_score + 60;
   Move best_move = Move::NullMove();
 
   Score static_eval = kScoreNone;
@@ -215,6 +216,11 @@ Score Search::QuiescentSearch(Score alpha,
     }
 
     if (!board_.IsMoveLegal(move)) {
+      continue;
+    }
+
+    if (!state.InCheck() && futility_score <= alpha && !eval::StaticExchange(move, 1, state)) {
+      best_score = std::max(best_score, futility_score);
       continue;
     }
 


### PR DESCRIPTION
```
Elo   | 7.80 +- 5.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7488 W: 1990 L: 1822 D: 3676
Penta | [144, 880, 1559, 986, 175]
https://chess.aronpetkovski.com/test/1449/
```

Bench: 3177312