### PR TITLE
Fix bound determination for TT score replacing static eval

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -182,9 +182,12 @@ Score Search::QuiescentSearch(Score alpha,
   Score best_score = kScoreNone;
 
   if (!state.InCheck()) {
-    best_score = can_use_tt_eval
-                   ? tt_entry.score
-                   : history_.correction_history->CorrectedStaticEval();
+    if (tt_hit &&
+        tt_entry.CanUseScore(stack->static_eval, stack->static_eval)) {
+      best_score = tt_entry.score;
+    } else {
+      best_score = history_.correction_history->CorrectedStaticEval();
+    }
 
     // Early beta cutoff
     if (best_score >= beta) {
@@ -353,7 +356,8 @@ Score Search::PVSearch(int depth,
     stack->static_eval = history_.correction_history->CorrectedStaticEval();
 
     // Adjust eval depending on if we can use the score stored in the TT
-    if (can_use_tt_eval) {
+    if (tt_hit &&
+        tt_entry.CanUseScore(stack->static_eval, stack->static_eval)) {
       eval = TranspositionTableEntry::CorrectScore(tt_entry.score, stack->ply);
     } else {
       eval = stack->static_eval;


### PR DESCRIPTION
```
Elo   | 1.63 +- 3.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.29 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 15568 W: 4106 L: 4033 D: 7429
Penta | [281, 1878, 3397, 1943, 285]
https://chess.aronpetkovski.com/test/1741/
```