### PR TITLE
Fix static eval not being initialized in QS

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -182,12 +182,14 @@ Score Search::QuiescentSearch(Score alpha,
   Score best_score = kScoreNone;
 
   if (!state.InCheck()) {
+    stack->static_eval = eval::Evaluate(state);
+
     if (tt_hit &&
         tt_entry.CanUseScore(stack->static_eval, stack->static_eval)) {
       best_score = tt_entry.score;
     } else {
       best_score =
-          history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
+          history_.correction_history->CorrectStaticEval(stack->static_eval);
     }
 
     // Early beta cutoff
@@ -475,7 +477,6 @@ Score Search::PVSearch(int depth,
         move_picker.SkipQuiets();
         continue;
       }
-
       // Futility Pruning: Skip (futile) quiet moves at near-leaf nodes when
       // there's a low chance to raise alpha
       const int futility_margin = fut_margin_base + fut_margin_mult * depth;


### PR DESCRIPTION
```
Elo   | 0.69 +- 2.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 19680 W: 5011 L: 4972 D: 9697
Penta | [311, 2391, 4416, 2392, 330]
https://chess.aronpetkovski.com/test/1893/
```