### PR TITLE
Different correction history logic

### DIFF
--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -30,7 +30,8 @@ class CorrectionHistory {
     const int weight = std::min(1 + depth, 16);
 
     auto &score = table_[state_.turn][GetTableIndex()];
-    score = (score * (256 - weight) + scaled_bonus * weight) / 256;
+    score = (score * (corr_history_scale - weight) + scaled_bonus * weight) /
+            corr_history_scale;
     score = std::clamp<Score>(score,
                               corr_history_scale * -max_corr_hist,
                               corr_history_scale * max_corr_hist);

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -7,10 +7,9 @@
 
 namespace history {
 
-inline Tunable corr_history_size("corr_history_size", 15221, 8192, 32768, 1024);
-inline Tunable corr_history_divisor(
-    "corr_history_divisor", 14457, 8192, 32768, 1024);
-inline Tunable corr_history_gravity("corr_history_gravity", 582, 256, 1024, 32);
+inline Tunable corr_history_size("corr_history_size", 16384, 8192, 32768, 1024);
+inline Tunable corr_history_scale("corr_history_scale", 256, 100, 500, 15);
+inline Tunable max_corr_hist("max_corr_hist", 64, 16, 128, 6);
 
 class CorrectionHistory {
  public:
@@ -26,21 +25,21 @@ class CorrectionHistory {
     }
 
     const Score static_eval_error = search_score - stack->static_eval;
-    const int bonus = std::clamp(static_eval_error * depth / 8,
-                                 -static_cast<int>(corr_history_gravity) / 4,
-                                 static_cast<int>(corr_history_gravity) / 4);
+    const int scaled_bonus =
+        static_eval_error * static_cast<int>(corr_history_scale);
+    const int weight = std::min(1 + depth, 16);
 
-    // Apply a linear dampening to the bonus as the depth increases
     Score &score = table_[state_.turn][GetTableIndex()];
-    score += ScaleBonus(score, bonus, corr_history_gravity);
+    score = (score * (256 - weight) + scaled_bonus * weight) / 256;
+    score = std::clamp(score,
+                       -kMateScore + kMaxPlyFromRoot + 1,
+                       kMateScore - kMaxPlyFromRoot - 1);
   }
 
   [[nodiscard]] Score CorrectStaticEval(Score static_eval) const {
     const Score correction = table_[state_.turn][GetTableIndex()];
     const Score adjusted_score =
-        static_eval + (correction * std::abs(correction)) /
-                          static_cast<int>(corr_history_divisor);
-
+        static_eval + correction / static_cast<int>(corr_history_scale);
     // Ensure no static evaluations are mate scores
     return std::clamp(adjusted_score,
                       -kMateScore + kMaxPlyFromRoot + 1,

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -31,9 +31,7 @@ class CorrectionHistory {
 
     Score &score = table_[state_.turn][GetTableIndex()];
     score = (score * (256 - weight) + scaled_bonus * weight) / 256;
-    score = std::clamp(score,
-                       -kMateScore + kMaxPlyFromRoot + 1,
-                       kMateScore - kMaxPlyFromRoot - 1);
+    score = std::clamp<Score>(score, -max_corr_hist, max_corr_hist);
   }
 
   [[nodiscard]] Score CorrectStaticEval(Score static_eval) const {

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -29,9 +29,11 @@ class CorrectionHistory {
         static_eval_error * static_cast<int>(corr_history_scale);
     const int weight = std::min(1 + depth, 16);
 
-    Score &score = table_[state_.turn][GetTableIndex()];
+    auto &score = table_[state_.turn][GetTableIndex()];
     score = (score * (256 - weight) + scaled_bonus * weight) / 256;
-    score = std::clamp<Score>(score, -max_corr_hist, max_corr_hist);
+    score = std::clamp<Score>(score,
+                              corr_history_scale * -max_corr_hist,
+                              corr_history_scale * max_corr_hist);
   }
 
   [[nodiscard]] Score CorrectStaticEval(Score static_eval) const {

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -189,14 +189,14 @@ Score Search::QuiescentSearch(Score alpha,
   Score best_score = kScoreNone;
 
   if (!state.InCheck()) {
-    stack->static_eval = eval::Evaluate(state);
+    stack->static_eval =
+        history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
 
     if (tt_hit &&
         tt_entry.CanUseScore(stack->static_eval, stack->static_eval)) {
       best_score = tt_entry.score;
     } else {
-      best_score =
-          history_.correction_history->CorrectStaticEval(stack->static_eval);
+      best_score = stack->static_eval;
     }
 
     // Early beta cutoff
@@ -365,7 +365,8 @@ Score Search::PVSearch(int depth,
   if (state.InCheck()) {
     stack->static_eval = stack->eval = kScoreNone;
   } else if (!stack->excluded_tt_move) {
-    stack->static_eval = eval::Evaluate(state);
+    stack->static_eval =
+        history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
 
     // Adjust eval depending on if we can use the score stored in the TT
     if (tt_hit &&
@@ -373,8 +374,7 @@ Score Search::PVSearch(int depth,
       stack->eval =
           TranspositionTableEntry::CorrectScore(tt_entry.score, stack->ply);
     } else {
-      stack->eval =
-          history_.correction_history->CorrectStaticEval(stack->static_eval);
+      stack->eval = stack->static_eval;
     }
   }
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -189,14 +189,14 @@ Score Search::QuiescentSearch(Score alpha,
   Score best_score = kScoreNone;
 
   if (!state.InCheck()) {
-    stack->static_eval =
-        history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
+    stack->static_eval = eval::Evaluate(state);
 
     if (tt_hit &&
         tt_entry.CanUseScore(stack->static_eval, stack->static_eval)) {
       best_score = tt_entry.score;
     } else {
-      best_score = stack->static_eval;
+      best_score =
+          history_.correction_history->CorrectStaticEval(stack->static_eval);
     }
 
     // Early beta cutoff
@@ -365,8 +365,7 @@ Score Search::PVSearch(int depth,
   if (state.InCheck()) {
     stack->static_eval = stack->eval = kScoreNone;
   } else if (!stack->excluded_tt_move) {
-    stack->static_eval =
-        history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
+    stack->static_eval = eval::Evaluate(state);
 
     // Adjust eval depending on if we can use the score stored in the TT
     if (tt_hit &&
@@ -374,7 +373,8 @@ Score Search::PVSearch(int depth,
       stack->eval =
           TranspositionTableEntry::CorrectScore(tt_entry.score, stack->ply);
     } else {
-      stack->eval = stack->static_eval;
+      stack->eval =
+          history_.correction_history->CorrectStaticEval(stack->static_eval);
     }
   }
 


### PR DESCRIPTION
```
Elo   | 9.75 +- 5.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5416 W: 1506 L: 1354 D: 2556
Penta | [86, 622, 1184, 686, 130]
https://chess.aronpetkovski.com/test/1978/
```