### PR TITLE
Always use corrected static eval

### DIFF
--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -7,7 +7,6 @@
 
 namespace history {
 
-inline Tunable corr_history_size("corr_history_size", 16384, 8192, 32768, 1024);
 inline Tunable corr_history_scale("corr_history_scale", 256, 100, 500, 15);
 inline Tunable max_corr_hist("max_corr_hist", 64, 16, 128, 6);
 
@@ -59,7 +58,7 @@ class CorrectionHistory {
   }
 
   [[nodiscard]] int GetTableIndex() const {
-    return state_.pawn_key & (static_cast<int>(corr_history_size) - 1);
+    return state_.pawn_key & 16383;
   }
 
  private:

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -189,14 +189,14 @@ Score Search::QuiescentSearch(Score alpha,
   Score best_score = kScoreNone;
 
   if (!state.InCheck()) {
-    stack->static_eval = eval::Evaluate(state);
+    stack->static_eval =
+        history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
 
     if (tt_hit &&
         tt_entry.CanUseScore(stack->static_eval, stack->static_eval)) {
       best_score = tt_entry.score;
     } else {
-      best_score =
-          history_.correction_history->CorrectStaticEval(stack->static_eval);
+      best_score = stack->static_eval;
     }
 
     // Early beta cutoff
@@ -365,7 +365,8 @@ Score Search::PVSearch(int depth,
   if (state.InCheck()) {
     stack->static_eval = stack->eval = kScoreNone;
   } else if (!stack->excluded_tt_move) {
-    stack->static_eval = eval::Evaluate(state);
+    stack->static_eval =
+        history_.correction_history->CorrectStaticEval(eval::Evaluate(state));
 
     // Adjust eval depending on if we can use the score stored in the TT
     if (tt_hit &&
@@ -373,8 +374,7 @@ Score Search::PVSearch(int depth,
       stack->eval =
           TranspositionTableEntry::CorrectScore(tt_entry.score, stack->ply);
     } else {
-      stack->eval =
-          history_.correction_history->CorrectStaticEval(stack->static_eval);
+      stack->eval = stack->static_eval;
     }
   }
 


### PR DESCRIPTION
```
Elo   | 3.04 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34378 W: 9078 L: 8777 D: 16523
Penta | [607, 4013, 7611, 4388, 570]
https://chess.aronpetkovski.com/test/1990/
```