### PR TITLE
Store static eval in TT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ make <native|x86_64_bmi2|x86_64_modern|x86_64>
 ```
 
 ## Rating
-Integral is estimated to be around 3050 [CCRL](https://www.computerchess.org.uk/ccrl/) Blitz, which puts it at a super-human level.
+Integral is estimated to be around 3380 [CCRL](https://www.computerchess.org.uk/ccrl/) Blitz, which puts it at a super-human level.

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -482,6 +482,19 @@ Score Search::PVSearch(Thread &thread,
     raw_static_eval =
         tt_static_eval != kScoreNone ? tt_static_eval : eval::Evaluate(state);
 
+    // Save the static eval in the TT if we have nothing yet
+    if (!tt_hit) {
+      const TranspositionTableEntry new_tt_entry(state.zobrist_key,
+                                                 0,
+                                                 TranspositionTableEntry::kNone,
+                                                 kScoreNone,
+                                                 raw_static_eval,
+                                                 Move::NullMove(),
+                                                 tt_was_in_pv);
+      transposition_table.Save(
+          tt_entry, new_tt_entry, state.zobrist_key, stack->ply);
+    }
+
     stack->static_eval =
         history.correction_history->CorrectStaticEval(state, raw_static_eval);
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -489,7 +489,7 @@ Score Search::PVSearch(Thread &thread,
       // Save static eval in TT if there's no tt hit
       const TranspositionTableEntry new_tt_entry(
           state.zobrist_key,
-          depth,
+          0,
           TranspositionTableEntry::kLowerBound,
           kScoreNone,
           raw_static_eval,

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -479,25 +479,8 @@ Score Search::PVSearch(Thread &thread,
   if (state.InCheck()) {
     stack->static_eval = stack->eval = raw_static_eval = kScoreNone;
   } else if (!stack->excluded_tt_move) {
-    if (tt_static_eval != kScoreNone) {
-      raw_static_eval = tt_entry->static_eval;
-    } else {
-      raw_static_eval = eval::Evaluate(state);
-    }
-
-    if (!tt_hit) {
-      // Save static eval in TT if there's no tt hit
-      const TranspositionTableEntry new_tt_entry(
-          state.zobrist_key,
-          0,
-          TranspositionTableEntry::kLowerBound,
-          kScoreNone,
-          raw_static_eval,
-          Move::NullMove(),
-          tt_was_in_pv);
-      transposition_table.Save(
-          tt_entry, new_tt_entry, state.zobrist_key, stack->ply);
-    }
+    raw_static_eval =
+        tt_static_eval != kScoreNone ? tt_static_eval : eval::Evaluate(state);
 
     stack->static_eval =
         history.correction_history->CorrectStaticEval(state, raw_static_eval);

--- a/src/engine/search/transpo.cc
+++ b/src/engine/search/transpo.cc
@@ -49,6 +49,7 @@ void TranspositionTable::Save(TranspositionTableEntry *old_entry,
         TranspositionTableEntry::CorrectScore(new_entry.score, -ply);
     old_entry->depth = new_entry.depth;
     old_entry->bits = new_entry.bits;
+    old_entry->static_eval = new_entry.static_eval;
   }
 }
 

--- a/src/engine/search/transpo.h
+++ b/src/engine/search/transpo.h
@@ -12,6 +12,7 @@ namespace search {
 
 struct TranspositionTableEntry {
   enum Flag : U8 {
+    kNone,
     kExact,
     kLowerBound,
     kUpperBound
@@ -23,7 +24,9 @@ struct TranspositionTableEntry {
         score(kScoreNone),
         static_eval(0),
         move(Move::NullMove()),
-        bits(0) {}
+        bits(0) {
+    SetFlag(kNone);
+  }
 
   explicit TranspositionTableEntry(U64 key,
                                    U8 depth,

--- a/src/engine/search/transpo.h
+++ b/src/engine/search/transpo.h
@@ -18,13 +18,24 @@ struct TranspositionTableEntry {
   };
 
   TranspositionTableEntry()
-      : key(0), depth(0), score(kScoreNone), move(Move::NullMove()), bits(0) {}
+      : key(0),
+        depth(0),
+        score(kScoreNone),
+        static_eval(0),
+        move(Move::NullMove()),
+        bits(0) {}
 
-  explicit TranspositionTableEntry(
-      U64 key, U8 depth, Flag flag, Score score, Move move, bool was_in_pv)
+  explicit TranspositionTableEntry(U64 key,
+                                   U8 depth,
+                                   Flag flag,
+                                   Score score,
+                                   Score static_eval,
+                                   Move move,
+                                   bool was_in_pv)
       : key(static_cast<U16>(key)),
         depth(depth),
         score(score),
+        static_eval(static_eval),
         move(move),
         bits(0) {
     SetWasPV(was_in_pv);
@@ -57,7 +68,7 @@ struct TranspositionTableEntry {
   }
 
   U16 key;
-  I16 score;
+  I16 score, static_eval;
   Move move;
   U8 depth;
   union {
@@ -93,12 +104,13 @@ struct TranspositionTableEntry {
   }
 };
 
-static_assert(sizeof(TranspositionTableEntry) == 8);
+static_assert(sizeof(TranspositionTableEntry) == 10);
 
-constexpr int kTTClusterSize = 4;
+constexpr int kTTClusterSize = 3;
 
 struct TranspositionTableCluster {
   std::array<TranspositionTableEntry, kTTClusterSize> entries;
+  U16 padding;
 };
 
 constexpr int kMaxTTAge = 64;


### PR DESCRIPTION
```
Elo   | 14.22 +- 7.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3202 W: 887 L: 756 D: 1559
Penta | [32, 329, 773, 410, 57]
https://chess.aronpetkovski.com/test/2957/
```