### PR TITLE
More aggressive NMP

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -19,7 +19,7 @@ Tunable qs_fut_margin("qs_fut_margin", 101, 50, 200, 10);
 Tunable rev_fut_depth("rev_fut_depth", 6, 4, 10, 1, true);
 Tunable rev_fut_margin("rev_fut_margin", 74, 50, 150, 8);
 
-Tunable null_move_rb("null_move_rb", 3, 1, 5, 0.5);
+Tunable null_move_rb("null_move_rb", 4, 1, 5, 0.5);
 Tunable null_move_rf("null_move_rf", 4, 2, 8, 1, true);
 Tunable null_move_re("null_move_re", 202, 100, 400, 20);
 


### PR DESCRIPTION
```
Elo   | 4.62 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12706 W: 3297 L: 3128 D: 6281
Penta | [141, 1457, 2995, 1612, 148]
https://chess.aronpetkovski.com/test/3310/
```