### PR TITLE
Only NMP when static eval is above beta

### DIFF
--- a/src/engine/search/history/history.h
+++ b/src/engine/search/history/history.h
@@ -42,6 +42,14 @@ class History {
     return capture_history->GetScore(state, move);
   }
 
+  [[nodiscard]] int GetMoveScore(const BoardState &state,
+                                 Move move,
+                                 BitBoard threats) const {
+    return move.IsCapture(state)
+             ? capture_history->GetScore(state, move)
+             : quiet_history->GetScore(state, move, threats);
+  }
+
  public:
   std::unique_ptr<QuietHistory> quiet_history;
   std::unique_ptr<CaptureHistory> capture_history;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -541,7 +541,9 @@ Score Search::PVSearch(Thread &thread,
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= rev_fut_depth && stack->eval < kMateScore - kMaxPlyFromRoot &&
-        !stack->excluded_tt_move) {
+        !stack->excluded_tt_move &&
+        (!tt_move ||
+         history.GetMoveScore(state, tt_move, state.threats) > 5000)) {
       const int futility_margin = depth * (improving ? 40 : 74);
       if (stack->eval - futility_margin >= beta) {
         return stack->eval;


### PR DESCRIPTION
```
Elo   | 13.31 +- 6.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3526 W: 985 L: 850 D: 1691
Penta | [41, 368, 837, 449, 68]
https://chess.aronpetkovski.com/test/3367/
```