### PR TITLE
Only NMP when static eval is above beta

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -551,6 +551,7 @@ Score Search::PVSearch(Thread &thread,
     // Null Move Pruning: Forfeit a move to our opponent and cutoff if we still
     // have the advantage
     if (!(stack - 1)->move.IsNull() && stack->eval >= beta &&
+        stack->static_eval >= beta + 170 - 24 * depth &&
         !stack->excluded_tt_move) {
       // Avoid null move pruning a position with high zugzwang potential
       const BitBoard non_pawn_king_pieces =


### PR DESCRIPTION
```
Elo   | 13.31 +- 6.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3526 W: 985 L: 850 D: 1691
Penta | [41, 368, 837, 449, 68]
https://chess.aronpetkovski.com/test/3367/
```