### PR TITLE
Use previous move history in RFP margin

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -543,7 +543,7 @@ Score Search::PVSearch(Thread &thread,
     if (depth <= rev_fut_depth && stack->eval < kMateScore - kMaxPlyFromRoot &&
         stack->eval >= beta && !stack->excluded_tt_move) {
       const int futility_margin =
-          depth * (improving ? 40 : 74) - (stack - 1)->history_score / 128;
+          depth * (improving ? 40 : 74) + (stack - 1)->history_score / 128;
       if (stack->eval - futility_margin >= beta) {
         return stack->eval;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -541,9 +541,9 @@ Score Search::PVSearch(Thread &thread,
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= rev_fut_depth && stack->eval < kMateScore - kMaxPlyFromRoot &&
-        stack->eval >= beta && !stack->excluded_tt_move) {
+        !stack->excluded_tt_move) {
       const int futility_margin =
-          depth * (improving ? 40 : 74) + (stack - 1)->history_score / 400;
+          depth * (improving ? 40 : 74) + (stack - 1)->history_score / 600;
       if (stack->eval - futility_margin >= beta) {
         return stack->eval;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -543,7 +543,7 @@ Score Search::PVSearch(Thread &thread,
     if (depth <= rev_fut_depth && stack->eval < kMateScore - kMaxPlyFromRoot &&
         stack->eval >= beta && !stack->excluded_tt_move) {
       const int futility_margin =
-          depth * (improving ? 40 : 74) + (stack - 1)->history_score / 128;
+          depth * (improving ? 40 : 74) + (stack - 1)->history_score / 400;
       if (stack->eval - futility_margin >= beta) {
         return stack->eval;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -541,8 +541,9 @@ Score Search::PVSearch(Thread &thread,
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= rev_fut_depth && stack->eval < kMateScore - kMaxPlyFromRoot &&
-        !stack->excluded_tt_move) {
-      const int futility_margin = depth * (improving ? 40 : 74);
+        stack->eval >= beta && !stack->excluded_tt_move) {
+      const int futility_margin =
+          depth * (improving ? 40 : 74) - (stack - 1)->history_score / 128;
       if (stack->eval - futility_margin >= beta) {
         return stack->eval;
       }
@@ -682,7 +683,8 @@ Score Search::PVSearch(Thread &thread,
 
     const bool is_quiet = !move.IsNoisy(state);
     const bool is_capture = move.IsCapture(state);
-    const int history_score =
+
+    stack->history_score =
         is_capture ? history.GetCaptureMoveScore(state, move)
                    : history.GetQuietMoveScore(state, move, threats, stack);
 
@@ -720,7 +722,8 @@ Score Search::PVSearch(Thread &thread,
       // near-leaf nodes
       if (is_quiet) {
         if (depth <= hist_prune_depth &&
-            history_score <= hist_thresh_base + hist_thresh_mult * depth) {
+            stack->history_score <=
+                hist_thresh_base + hist_thresh_mult * depth) {
           move_picker.SkipQuiets();
           continue;
         }
@@ -808,8 +811,9 @@ Score Search::PVSearch(Thread &thread,
       int reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
       reduction += !in_pv_node - tt_was_in_pv;
       reduction += cut_node;
-      reduction -= is_quiet * history_score / static_cast<int>(lmr_hist_div);
       reduction -= gives_check;
+      if (is_quiet)
+        reduction -= stack->history_score / static_cast<int>(lmr_hist_div);
 
       // Ensure the reduction doesn't give us a depth below 0
       reduction = std::clamp<int>(reduction, 0, new_depth - 1);

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -54,8 +54,8 @@ struct PVLine {
 struct StackEntry {
   // Number of ply from root
   U16 ply;
-  // Evaluation of the position at this ply
-  Score static_eval, eval;
+  // Scores at this ply
+  Score static_eval, eval, history_score;
   // Best moves following down this ply
   PVLine pv;
   // The move with the best score

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -55,7 +55,8 @@ struct StackEntry {
   // Number of ply from root
   U16 ply;
   // Scores at this ply
-  Score static_eval, eval, history_score;
+  Score static_eval, eval;
+  I64 history_score;
   // Best moves following down this ply
   PVLine pv;
   // The move with the best score

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -89,6 +89,7 @@ struct StackEntry {
       : ply(ply),
         static_eval(kScoreNone),
         eval(kScoreNone),
+        history_score(0),
         best_move(Move::NullMove()),
         move(Move::NullMove()),
         excluded_tt_move(Move::NullMove()),


### PR DESCRIPTION
```
Elo   | 3.25 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 22896 W: 5995 L: 5781 D: 11120
Penta | [249, 2754, 5280, 2864, 301]
https://chess.aronpetkovski.com/test/3381/
```