### PR TITLE
Fix Capture History Penalty

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -906,16 +906,18 @@ Score Search::PVSearch(Thread &thread,
         quiets.Push(move);
       else if (is_capture)
         captures.Push(move);
-
-      // Since "good" captures are expected to be the best moves, we apply a
-      // penalty to all captures even in the case where the best move was quiet
-      history.capture_history->Penalize(state, depth, captures);
     }
   }
 
   // Terminal state if no legal moves were found
   if (moves_seen == 0) {
     return in_check ? -kMateScore + stack->ply : kDrawScore;
+  }
+
+  if (best_move) {
+    // Since "good" captures are expected to be the best moves, we apply a
+    // penalty to all captures even in the case where the best move was quiet
+    history.capture_history->Penalize(state, depth, captures);
   }
 
   if (syzygy::enabled) {


### PR DESCRIPTION
```
Elo   | 6.55 +- 4.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 6790 W: 1849 L: 1721 D: 3220
Penta | [93, 764, 1557, 884, 97]
https://chess.aronpetkovski.com/test/3461/
```