### PR TITLE
Capture History Pruning

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -42,6 +42,8 @@ Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
+Tunable capt_hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
+Tunable capt_hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 
 Tunable lmr_hist_div("lmr_hist_div", 11432, 5000, 20000, 750);
 Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -42,8 +42,8 @@ Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
-Tunable capt_hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
-Tunable capt_hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
+Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);
+Tunable capt_hist_thresh_mult("capt_hist_thresh_mult", -1695, -3000, -250, 300);
 
 Tunable lmr_hist_div("lmr_hist_div", 11432, 5000, 20000, 750);
 Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -733,13 +733,12 @@ Score Search::PVSearch(Thread &thread,
 
       // History Pruning: Prune quiet moves with a low history score moves at
       // near-leaf nodes
-      if (is_quiet) {
-        if (depth <= hist_prune_depth &&
-            stack->history_score <=
-                hist_thresh_base + hist_thresh_mult * depth) {
-          move_picker.SkipQuiets();
-          continue;
-        }
+      const int history_margin =
+          is_quiet ? hist_thresh_base + hist_thresh_mult * depth
+                   : capt_hist_thresh_base + capt_hist_thresh_mult * depth;
+      if (depth <= hist_prune_depth && stack->history_score <= history_margin) {
+        move_picker.SkipQuiets();
+        continue;
       }
     }
 


### PR DESCRIPTION
```
Elo   | 5.29 +- 3.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10710 W: 2789 L: 2626 D: 5295
Penta | [127, 1231, 2495, 1356, 146]
https://chess.aronpetkovski.com/test/3468/
```