### PR TITLE
Negative extensions in cutnodes

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -787,7 +787,7 @@ Score Search::PVSearch(Thread &thread,
         }
         // Negative Extensions: Search less since the TT move was not singular,
         // and it might cause a beta cutoff again.
-        else if (tt_entry->score >= beta) {
+        else if (tt_entry->score >= beta || cut_node) {
           extensions = -1;
         }
       }


### PR DESCRIPTION
```
Elo   | 5.67 +- 4.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9748 W: 2548 L: 2389 D: 4811
Penta | [106, 1137, 2243, 1268, 120]
https://chess.aronpetkovski.com/test/3480/
```