### PR TITLE
Use LMR depth in Futility Pruning

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -39,7 +39,7 @@ Tunable see_prune_depth("see_prune_depth", 8, 6, 12, 1, true);
 Tunable see_quiet_thresh("see_quiet_thresh", -64, -100, -20, 6);
 Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 
-Tunable hist_prune_depth("hist_prune_depth", 3, 3, 8, 1, true);
+Tunable hist_prune_depth("hist_prune_depth", 2, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -39,7 +39,7 @@ Tunable see_prune_depth("see_prune_depth", 8, 6, 12, 1, true);
 Tunable see_quiet_thresh("see_quiet_thresh", -64, -100, -20, 6);
 Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 
-Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
+Tunable hist_prune_depth("hist_prune_depth", 3, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -39,7 +39,7 @@ Tunable see_prune_depth("see_prune_depth", 8, 6, 12, 1, true);
 Tunable see_quiet_thresh("see_quiet_thresh", -64, -100, -20, 6);
 Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 
-Tunable hist_prune_depth("hist_prune_depth", 2, 3, 8, 1, true);
+Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -39,7 +39,7 @@ Tunable see_prune_depth("see_prune_depth", 8, 6, 12, 1, true);
 Tunable see_quiet_thresh("see_quiet_thresh", -64, -100, -20, 6);
 Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 
-Tunable hist_prune_depth("hist_prune_depth", 3, 3, 8, 1, true);
+Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -39,7 +39,7 @@ Tunable see_prune_depth("see_prune_depth", 8, 6, 12, 1, true);
 Tunable see_quiet_thresh("see_quiet_thresh", -64, -100, -20, 6);
 Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 
-Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
+Tunable hist_prune_depth("hist_prune_depth", 4, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -39,7 +39,7 @@ Tunable see_prune_depth("see_prune_depth", 8, 6, 12, 1, true);
 Tunable see_quiet_thresh("see_quiet_thresh", -64, -100, -20, 6);
 Tunable see_noisy_thresh("see_noisy_thresh", -119, -200, -50, 8);
 
-Tunable hist_prune_depth("hist_prune_depth", 4, 3, 8, 1, true);
+Tunable hist_prune_depth("hist_prune_depth", 5, 3, 8, 1, true);
 Tunable hist_thresh_base("hist_thresh_base", -480, -1000, 500, 100);
 Tunable hist_thresh_mult("hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable capt_hist_thresh_base("capt_hist_thresh_base", -480, -1000, 500, 100);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -707,7 +707,7 @@ Score Search::PVSearch(Thread &thread,
       reduction -=
           stack->history_score /
           static_cast<int>(is_quiet ? lmr_hist_div : lmr_capt_hist_div);
-      const int lmr_depth = depth - 1 - reduction;
+      const int lmr_depth = std::max(depth - reduction, 0);
 
       // Late Move Pruning: Skip (late) quiet moves if we've already searched
       // the most promising moves
@@ -723,7 +723,7 @@ Score Search::PVSearch(Thread &thread,
       // there's a low chance to raise alpha
       const int futility_margin = fut_margin_base + fut_margin_mult * lmr_depth;
       if (lmr_depth <= fut_prune_depth && !in_check && is_quiet &&
-          stack->static_eval + futility_margin < alpha) {
+          stack->eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
         continue;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -794,7 +794,7 @@ Score Search::PVSearch(Thread &thread,
         }
         // Negative Extensions: Search less since the TT move was not singular,
         // and it might cause a beta cutoff again.
-        else if (tt_entry->score >= beta) {
+        else if (tt_entry->score >= beta || cut_node) {
           extensions = -1;
         }
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -740,8 +740,8 @@ Score Search::PVSearch(Thread &thread,
       // History Pruning: Prune quiet moves with a low history score moves at
       // near-leaf nodes
       const int history_margin =
-          is_quiet ? hist_thresh_base + hist_thresh_mult * depth
-                   : capt_hist_thresh_base + capt_hist_thresh_mult * depth;
+          is_quiet ? hist_thresh_base + hist_thresh_mult * lmr_depth
+                   : capt_hist_thresh_base + capt_hist_thresh_mult * lmr_depth;
       if (lmr_depth <= hist_prune_depth &&
           stack->history_score <= history_margin) {
         move_picker.SkipQuiets();

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -787,7 +787,7 @@ Score Search::PVSearch(Thread &thread,
         }
         // Negative Extensions: Search less since the TT move was not singular,
         // and it might cause a beta cutoff again.
-        else if (tt_entry->score >= beta) {
+        else if (tt_entry->score >= beta || cut_node) {
           extensions = -1;
         }
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -721,8 +721,8 @@ Score Search::PVSearch(Thread &thread,
 
       // Futility Pruning: Skip (futile) quiet moves at near-leaf nodes when
       // there's a low chance to raise alpha
-      const int futility_margin = fut_margin_base + fut_margin_mult * depth;
-      if (depth <= fut_prune_depth && !in_check && is_quiet &&
+      const int futility_margin = fut_margin_base + fut_margin_mult * lmr_depth;
+      if (lmr_depth <= fut_prune_depth && !in_check && is_quiet &&
           stack->eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
         continue;
@@ -740,10 +740,9 @@ Score Search::PVSearch(Thread &thread,
       // History Pruning: Prune quiet moves with a low history score moves at
       // near-leaf nodes
       const int history_margin =
-          is_quiet ? hist_thresh_base + hist_thresh_mult * lmr_depth
-                   : capt_hist_thresh_base + capt_hist_thresh_mult * lmr_depth;
-      if (lmr_depth <= hist_prune_depth &&
-          stack->history_score <= history_margin) {
+          is_quiet ? hist_thresh_base + hist_thresh_mult * depth
+                   : capt_hist_thresh_base + capt_hist_thresh_mult * depth;
+      if (depth <= hist_prune_depth && stack->history_score <= history_margin) {
         move_picker.SkipQuiets();
         continue;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -723,7 +723,7 @@ Score Search::PVSearch(Thread &thread,
       // there's a low chance to raise alpha
       const int futility_margin = fut_margin_base + fut_margin_mult * lmr_depth;
       if (lmr_depth <= fut_prune_depth && !in_check && is_quiet &&
-          stack->eval + futility_margin < alpha) {
+          stack->static_eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
         continue;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -703,11 +703,11 @@ Score Search::PVSearch(Thread &thread,
 
     // Pruning guards
     if (!in_root && best_score > -kMateScore + kMaxPlyFromRoot) {
-      int lmr_reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
-      lmr_reduction -=
+      int reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
+      reduction -=
           stack->history_score /
           static_cast<int>(is_quiet ? lmr_hist_div : lmr_capt_hist_div);
-      const int lmr_depth = depth - 1 - lmr_reduction;
+      const int lmr_depth = depth - 1 - reduction;
 
       // Late Move Pruning: Skip (late) quiet moves if we've already searched
       // the most promising moves
@@ -742,7 +742,8 @@ Score Search::PVSearch(Thread &thread,
       const int history_margin =
           is_quiet ? hist_thresh_base + hist_thresh_mult * depth
                    : capt_hist_thresh_base + capt_hist_thresh_mult * depth;
-      if (lmr_depth <= hist_prune_depth && stack->history_score <= history_margin) {
+      if (lmr_depth <= hist_prune_depth &&
+          stack->history_score <= history_margin) {
         move_picker.SkipQuiets();
         continue;
       }


### PR DESCRIPTION
```
Elo   | 1.67 +- 1.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 83984 W: 21158 L: 20755 D: 42071
Penta | [951, 9951, 19758, 10408, 924]
```