### PR TITLE
Lower singular extension depth limit

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 15, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 7, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 7, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 17, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 17, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 28, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 10, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 15, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 28, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 10, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -799,7 +799,7 @@ Score Search::PVSearch(Thread &thread,
 
     // Check Extensions: Integral's not yet strong enough to simplify this out
     if (in_check) {
-      extensions = std::max(extensions, 1);
+      ++extensions;
     }
 
     // Set the currently searched move in the stack for continuation history

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -752,7 +752,7 @@ Score Search::PVSearch(Thread &thread,
     // Singular Extensions: If a TT move exists and its score is accurate enough
     // (close enough in depth), we perform a reduced-depth search with the TT
     // move excluded to see if any other moves can beat it.
-    if (!in_root && depth >= 8 && move == tt_move &&
+    if (!in_root && depth >= 6 && move == tt_move &&
         stack->ply < thread.root_depth * 2) {
       const bool is_accurate_tt_score =
           tt_entry->depth + 4 >= depth &&
@@ -761,7 +761,7 @@ Score Search::PVSearch(Thread &thread,
 
       if (is_accurate_tt_score) {
         const int reduced_depth = (depth - 1) / 2;
-        const Score new_beta = tt_entry->score - depth;
+        const Score new_beta = tt_entry->score - depth * 2;
 
         stack->excluded_tt_move = tt_move;
         const Score tt_move_excluded_score = PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -67,7 +67,7 @@ void Search::IterativeDeepening(Thread &thread) {
   Score score = 0;
 
   for (int depth = 1; depth <= time_mgmt_.GetSearchDepth(); depth++) {
-    thread.sel_depth = 0;
+    thread.sel_depth = 0, thread.root_depth = depth;
 
     int window = static_cast<int>(asp_window_delta);
     Score alpha = -kInfiniteScore;
@@ -536,7 +536,6 @@ Score Search::PVSearch(Thread &thread,
         past_stack->improving_rate + diff / improving_rate_divisor, -1.0, 1.0);
   }
 
-  stack->double_extensions = (stack - 1)->double_extensions;
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !in_check) {
@@ -753,7 +752,8 @@ Score Search::PVSearch(Thread &thread,
     // Singular Extensions: If a TT move exists and its score is accurate enough
     // (close enough in depth), we perform a reduced-depth search with the TT
     // move excluded to see if any other moves can beat it.
-    if (!in_root && depth >= 8 && move == tt_move) {
+    if (!in_root && depth >= 8 && move == tt_move &&
+        stack->ply < thread.root_depth * 2) {
       const bool is_accurate_tt_score =
           tt_entry->depth + 4 >= depth &&
           tt_entry->GetFlag() != TranspositionTableEntry::kUpperBound &&
@@ -777,10 +777,8 @@ Score Search::PVSearch(Thread &thread,
         if (tt_move_excluded_score < new_beta) {
           // Double extend if the TT move is singular by a big margin
           if (!in_pv_node &&
-              tt_move_excluded_score < new_beta - sing_double_margin &&
-              (stack->double_extensions <= 8)) {
+              tt_move_excluded_score < new_beta - sing_double_margin) {
             extensions = 2;
-            stack->double_extensions++;
           } else {
             extensions = 1;
           }
@@ -801,7 +799,7 @@ Score Search::PVSearch(Thread &thread,
 
     // Check Extensions: Integral's not yet strong enough to simplify this out
     if (in_check) {
-      extensions++;
+      extensions = std::max(extensions, 1);
     }
 
     // Set the currently searched move in the stack for continuation history

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -761,7 +761,7 @@ Score Search::PVSearch(Thread &thread,
 
       if (is_accurate_tt_score) {
         const int reduced_depth = (depth - 1) / 2;
-        const Score new_beta = tt_entry->score - depth * sing_ext_margin;
+        const Score new_beta = tt_entry->score - depth;
 
         stack->excluded_tt_move = tt_move;
         const Score tt_move_excluded_score = PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.h
+++ b/src/engine/search/search.h
@@ -55,7 +55,7 @@ struct Thread {
   history::History history;
   Stack stack;
   std::atomic<U64> nodes_searched;
-  U16 sel_depth;
+  U16 root_depth, sel_depth;
   U64 tb_hits;
 };
 

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -71,8 +71,6 @@ struct StackEntry {
   std::array<Move, 2> killer_moves;
   // Overall improving rate from the last couple plies
   double improving_rate;
-  // Number of double extensions performed
-  int double_extensions;
 
   void AddKillerMove(Move killer_move) {
     // Ensure we don't have duplicate killer moves
@@ -96,8 +94,7 @@ struct StackEntry {
         excluded_tt_move(Move::NullMove()),
         killer_moves({}),
         continuation_entry(nullptr),
-        improving_rate(kScoreNone),
-        double_extensions(0) {
+        improving_rate(kScoreNone) {
     ClearKillerMoves();
   }
 


### PR DESCRIPTION
```
Elo   | 3.24 +- 2.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 23946 W: 6293 L: 6070 D: 11583
Penta | [334, 2793, 5508, 2992, 346]
https://chess.aronpetkovski.com/test/3551/
```