### PR TITLE
Fixing TB accuracy & pruning guards

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 15, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 7, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 7, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 17, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 17, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 28, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 10, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 15, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -50,7 +50,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 28, 10, 40, 5);
+Tunable sing_double_margin("sing_double_margin", 10, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -59,8 +59,8 @@ class CorrectionHistory {
         static_eval + correction / static_cast<int>(corr_history_scale);
     // Ensure no static evaluations are mate scores
     return std::clamp(adjusted_score,
-                      -kMateScore + kMaxPlyFromRoot + 1,
-                      kMateScore - kMaxPlyFromRoot - 1);
+                      -kMateInMaxPlyScore + 1,
+                      kMateInMaxPlyScore - 1);
   }
 
  private:

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -535,7 +535,7 @@ Score Search::PVSearch(Thread &thread,
 
   (stack + 1)->ClearKillerMoves();
 
-  if (!in_pv_node && !in_check && std::abs(beta) <= kTBWinInMaxPlyScore) {
+  if (!in_pv_node && !in_check && stack->eval < kTBWinInMaxPlyScore) {
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= rev_fut_depth && !stack->excluded_tt_move) {
@@ -595,7 +595,7 @@ Score Search::PVSearch(Thread &thread,
       // cutoff, we attempt a shallower quiescent-like search and prune early if
       // possible
       const Score pc_beta = beta + probcut_beta_delta;
-      if (depth >= 5 && std::abs(beta) >= kTBWinInMaxPlyScore &&
+      if (depth >= 5 && std::abs(beta) < kTBWinInMaxPlyScore &&
           (!tt_hit || tt_entry->depth + 3 < depth ||
            tt_entry->score >= pc_beta)) {
         const int pc_see = pc_beta - raw_static_eval;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -799,7 +799,7 @@ Score Search::PVSearch(Thread &thread,
 
     // Check Extensions: Integral's not yet strong enough to simplify this out
     if (in_check) {
-      extensions = std::max(extensions, 1);
+      ++extensions;
     }
 
     // Set the currently searched move in the stack for continuation history

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -752,7 +752,7 @@ Score Search::PVSearch(Thread &thread,
     // Singular Extensions: If a TT move exists and its score is accurate enough
     // (close enough in depth), we perform a reduced-depth search with the TT
     // move excluded to see if any other moves can beat it.
-    if (!in_root && depth >= 8 && move == tt_move &&
+    if (!in_root && depth >= 6 && move == tt_move &&
         stack->ply < thread.root_depth * 2) {
       const bool is_accurate_tt_score =
           tt_entry->depth + 4 >= depth &&
@@ -761,7 +761,7 @@ Score Search::PVSearch(Thread &thread,
 
       if (is_accurate_tt_score) {
         const int reduced_depth = (depth - 1) / 2;
-        const Score new_beta = tt_entry->score - depth;
+        const Score new_beta = tt_entry->score - depth * 2;
 
         stack->excluded_tt_move = tt_move;
         const Score tt_move_excluded_score = PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -138,7 +138,7 @@ void Search::IterativeDeepening(Thread &thread) {
           nodes_searched * 1000 / time_mgmt_.TimeElapsed(),
           transposition_table.HashFull(),
           syzygy::enabled ? " tbhits " : "",
-          syzygy::enabled ? std::to_string(thread.tb_hits) + " " : "",
+          syzygy::enabled ? std::to_string(thread.tb_hits) : "",
           root_stack->pv.UCIFormat());
     }
   }
@@ -429,10 +429,7 @@ Score Search::PVSearch(Thread &thread,
   // Probe the Syzygy table bases
   int syzygy_min_score = -kMateScore, syzygy_max_score = kMateScore;
   if (syzygy::enabled && !in_root && !stack->excluded_tt_move &&
-      state.Occupied().PopCount() <= 7 && depth <= syzygy::probe_depth &&
-      state.fifty_moves_clock == 0 &&
-      !state.castle_rights.CanCastle(state.turn) &&
-      !state.castle_rights.CanCastle(FlipColor(state.turn))) {
+      state.Occupied().PopCount() <= 7) {
     const auto tb_result = syzygy::ProbePosition(state);
     if (tb_result != syzygy::ProbeResult::kFailed) {
       Score score;
@@ -452,8 +449,8 @@ Score Search::PVSearch(Thread &thread,
       ++thread.tb_hits;
 
       if (tt_flag == TranspositionTableEntry::kExact ||
-          (tt_flag == TranspositionTableEntry::kLowerBound ? score >= beta
-                                                           : score <= alpha)) {
+          tt_flag == TranspositionTableEntry::kUpperBound && score <= alpha ||
+          tt_flag == TranspositionTableEntry::kLowerBound && score >= beta) {
         // Save the table base score to the transposition table
         const TranspositionTableEntry new_tt_entry(state.zobrist_key,
                                                    depth,
@@ -538,11 +535,10 @@ Score Search::PVSearch(Thread &thread,
 
   (stack + 1)->ClearKillerMoves();
 
-  if (!in_pv_node && !in_check) {
+  if (!in_pv_node && !in_check && std::abs(beta) <= kTBWinInMaxPlyScore) {
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
-    if (depth <= rev_fut_depth && stack->eval < kMateScore - kMaxPlyFromRoot &&
-        !stack->excluded_tt_move) {
+    if (depth <= rev_fut_depth && !stack->excluded_tt_move) {
       const int futility_margin =
           depth * (improving ? 40 : 74) + (stack - 1)->history_score / 600;
       if (stack->eval - futility_margin >= beta) {
@@ -591,7 +587,7 @@ Score Search::PVSearch(Thread &thread,
         // Prune if the result from our null window search around beta indicates
         // that the opponent still doesn't gain an advantage from the null move
         if (score >= beta) {
-          return score >= kMateScore - kMaxPlyFromRoot ? beta : score;
+          return score >= kTBWinInMaxPlyScore ? beta : score;
         }
       }
 
@@ -599,7 +595,7 @@ Score Search::PVSearch(Thread &thread,
       // cutoff, we attempt a shallower quiescent-like search and prune early if
       // possible
       const Score pc_beta = beta + probcut_beta_delta;
-      if (depth >= 5 && !eval::IsMateScore(beta) &&
+      if (depth >= 5 && std::abs(beta) >= kTBWinInMaxPlyScore &&
           (!tt_hit || tt_entry->depth + 3 < depth ||
            tt_entry->score >= pc_beta)) {
         const int pc_see = pc_beta - raw_static_eval;
@@ -701,7 +697,7 @@ Score Search::PVSearch(Thread &thread,
                    : history.GetQuietMoveScore(state, move, threats, stack);
 
     // Pruning guards
-    if (!in_root && best_score > -kMateScore + kMaxPlyFromRoot) {
+    if (!in_root && best_score > -kTBWinInMaxPlyScore) {
       int reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
       reduction -=
           stack->history_score /
@@ -757,7 +753,7 @@ Score Search::PVSearch(Thread &thread,
       const bool is_accurate_tt_score =
           tt_entry->depth + 4 >= depth &&
           tt_entry->GetFlag() != TranspositionTableEntry::kUpperBound &&
-          std::abs(tt_entry->score) < kMateScore - kMaxPlyFromRoot;
+          std::abs(tt_entry->score) < kTBWinInMaxPlyScore;
 
       if (is_accurate_tt_score) {
         const int reduced_depth = (depth - 1) / 2;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -67,7 +67,7 @@ void Search::IterativeDeepening(Thread &thread) {
   Score score = 0;
 
   for (int depth = 1; depth <= time_mgmt_.GetSearchDepth(); depth++) {
-    thread.sel_depth = 0;
+    thread.sel_depth = 0, thread.root_depth = depth;
 
     int window = static_cast<int>(asp_window_delta);
     Score alpha = -kInfiniteScore;
@@ -536,7 +536,6 @@ Score Search::PVSearch(Thread &thread,
         past_stack->improving_rate + diff / improving_rate_divisor, -1.0, 1.0);
   }
 
-  stack->double_extensions = (stack - 1)->double_extensions;
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !in_check) {
@@ -753,7 +752,8 @@ Score Search::PVSearch(Thread &thread,
     // Singular Extensions: If a TT move exists and its score is accurate enough
     // (close enough in depth), we perform a reduced-depth search with the TT
     // move excluded to see if any other moves can beat it.
-    if (!in_root && depth >= 8 && move == tt_move) {
+    if (!in_root && depth >= 8 && move == tt_move &&
+        stack->ply < thread.root_depth * 2) {
       const bool is_accurate_tt_score =
           tt_entry->depth + 4 >= depth &&
           tt_entry->GetFlag() != TranspositionTableEntry::kUpperBound &&
@@ -777,10 +777,8 @@ Score Search::PVSearch(Thread &thread,
         if (tt_move_excluded_score < new_beta) {
           // Double extend if the TT move is singular by a big margin
           if (!in_pv_node &&
-              tt_move_excluded_score < new_beta - sing_double_margin &&
-              (stack->double_extensions <= 8)) {
+              tt_move_excluded_score < new_beta - sing_double_margin) {
             extensions = 2;
-            stack->double_extensions++;
           } else {
             extensions = 1;
           }
@@ -801,7 +799,7 @@ Score Search::PVSearch(Thread &thread,
 
     // Check Extensions: Integral's not yet strong enough to simplify this out
     if (in_check) {
-      extensions++;
+      extensions = std::max(extensions, 1);
     }
 
     // Set the currently searched move in the stack for continuation history

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -761,7 +761,7 @@ Score Search::PVSearch(Thread &thread,
 
       if (is_accurate_tt_score) {
         const int reduced_depth = (depth - 1) / 2;
-        const Score new_beta = tt_entry->score - depth * sing_ext_margin;
+        const Score new_beta = tt_entry->score - depth;
 
         stack->excluded_tt_move = tt_move;
         const Score tt_move_excluded_score = PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.h
+++ b/src/engine/search/search.h
@@ -55,7 +55,7 @@ struct Thread {
   history::History history;
   Stack stack;
   std::atomic<U64> nodes_searched;
-  U16 sel_depth;
+  U16 root_depth, sel_depth;
   U64 tb_hits;
 };
 

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -71,8 +71,6 @@ struct StackEntry {
   std::array<Move, 2> killer_moves;
   // Overall improving rate from the last couple plies
   double improving_rate;
-  // Number of double extensions performed
-  int double_extensions;
 
   void AddKillerMove(Move killer_move) {
     // Ensure we don't have duplicate killer moves
@@ -96,8 +94,7 @@ struct StackEntry {
         excluded_tt_move(Move::NullMove()),
         killer_moves({}),
         continuation_entry(nullptr),
-        improving_rate(kScoreNone),
-        double_extensions(0) {
+        improving_rate(kScoreNone) {
     ClearKillerMoves();
   }
 

--- a/src/engine/search/transpo.h
+++ b/src/engine/search/transpo.h
@@ -61,10 +61,9 @@ struct TranspositionTableEntry {
 
   // Adjusts mate scores to correctly indicate the ply until mate
   [[nodiscard]] static Score CorrectScore(Score score, U16 ply) {
-    constexpr int kRoughlyMate = kMateScore - kMaxPlyFromRoot;
-    if (score >= kRoughlyMate) {
+    if (score >= kMateInMaxPlyScore) {
       score -= ply;
-    } else if (score <= -kRoughlyMate) {
+    } else if (score <= -kMateInMaxPlyScore) {
       score += ply;
     }
     return score;

--- a/src/utils/types.h
+++ b/src/utils/types.h
@@ -283,8 +283,10 @@ class ScorePair {
 
 const Score kDrawScore = 0;
 const Score kMateScore = std::numeric_limits<I16>::max() - 1;
+const Score kMateInMaxPlyScore = kMateScore - kMaxPlyFromRoot;
 const Score kInfiniteScore = std::numeric_limits<I16>::max();
 const Score kTBWinScore = kMateScore - kMaxPlyFromRoot - 1;
+const Score kTBWinInMaxPlyScore = kTBWinScore - kMaxPlyFromRoot;
 const Score kScoreNone = -kInfiniteScore;
 
 #endif  // INTEGRAL_TYPES_H_


### PR DESCRIPTION
```
Elo   | 1.82 +- 3.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 17378 W: 4630 L: 4539 D: 8209
Penta | [238, 2042, 4082, 2045, 282]
https://chess.aronpetkovski.com/test/3560/
```