### PR TITLE
Use improving heuristic in futility pruning

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -720,7 +720,7 @@ Score Search::PVSearch(Thread &thread,
       reduction -=
           stack->history_score /
           static_cast<int>(is_quiet ? lmr_hist_div : lmr_capt_hist_div);
-      reduction += stack->improving_rate <= 0;
+      reduction += stack->improving_rate < 0;
       const int lmr_depth = std::max(depth - reduction, 0);
 
       // Late Move Pruning: Skip (late) quiet moves if we've already searched

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -720,7 +720,7 @@ Score Search::PVSearch(Thread &thread,
       reduction -=
           stack->history_score /
           static_cast<int>(is_quiet ? lmr_hist_div : lmr_capt_hist_div);
-      reduction += stack->improving_rate < 0;
+      reduction += !improving;
       const int lmr_depth = std::max(depth - reduction, 0);
 
       // Late Move Pruning: Skip (late) quiet moves if we've already searched

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -734,8 +734,10 @@ Score Search::PVSearch(Thread &thread,
 
       // Futility Pruning: Skip (futile) quiet moves at near-leaf nodes when
       // there's a low chance to raise alpha
-      const int futility_margin = fut_margin_base + fut_margin_mult * lmr_depth;
-      if (lmr_depth <= fut_prune_depth && !stack->in_check && is_quiet &&
+      const int futility_depth = lmr_depth - !improving;
+      const int futility_margin =
+          fut_margin_base + fut_margin_mult * futility_depth;
+      if (futility_depth <= fut_prune_depth && !stack->in_check && is_quiet &&
           stack->eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
         continue;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -720,6 +720,7 @@ Score Search::PVSearch(Thread &thread,
       reduction -=
           stack->history_score /
           static_cast<int>(is_quiet ? lmr_hist_div : lmr_capt_hist_div);
+      reduction += stack->improving_rate <= 0;
       const int lmr_depth = std::max(depth - reduction, 0);
 
       // Late Move Pruning: Skip (late) quiet moves if we've already searched
@@ -734,10 +735,8 @@ Score Search::PVSearch(Thread &thread,
 
       // Futility Pruning: Skip (futile) quiet moves at near-leaf nodes when
       // there's a low chance to raise alpha
-      const int futility_depth = lmr_depth - !improving;
-      const int futility_margin =
-          fut_margin_base + fut_margin_mult * futility_depth;
-      if (futility_depth <= fut_prune_depth && !stack->in_check && is_quiet &&
+      const int futility_margin = fut_margin_base + fut_margin_mult * lmr_depth;
+      if (lmr_depth <= fut_prune_depth && !stack->in_check && is_quiet &&
           stack->eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
         continue;


### PR DESCRIPTION
```
Elo   | 4.29 +- 3.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 13116 W: 3265 L: 3103 D: 6748
Penta | [80, 1539, 3161, 1695, 83]
https://chess.aronpetkovski.com/test/4229/
```