### PR TITLE
Simplify away dynamic improving (for now)

### DIFF
--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -70,8 +70,6 @@ struct StackEntry {
   void *continuation_entry;
   // Moves that caused a beta cutoff at this ply
   std::array<Move, 2> killer_moves;
-  // Overall improving rate from the last couple plies
-  double improving_rate;
   // Was in check at this ply
   bool in_check;
   // Threats
@@ -98,8 +96,7 @@ struct StackEntry {
         move(Move::NullMove()),
         excluded_tt_move(Move::NullMove()),
         killer_moves({}),
-        continuation_entry(nullptr),
-        improving_rate(kScoreNone) {
+        continuation_entry(nullptr) {
     ClearKillerMoves();
   }
 


### PR DESCRIPTION
One of the saddest patches I've had to do in a while. I will experiment with getting dynamic improving to work again later on, but in the quest for Elo, it must go away for now.

STC
```
Elo   | 3.17 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21790 W: 5761 L: 5562 D: 10467
Penta | [147, 2592, 5250, 2727, 179]
https://chess.aronpetkovski.com/test/4264/
```

LTC (unfinished)
```
Elo   | 13.25 +- 9.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.46 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1548 W: 419 L: 360 D: 769
Penta | [6, 158, 387, 217, 6]
https://chess.aronpetkovski.com/test/4279/
```