### PR TITLE
Scale NNUE evaluation based on game phase

### DIFF
--- a/src/engine/evaluation/evaluation.cc
+++ b/src/engine/evaluation/evaluation.cc
@@ -5,7 +5,18 @@
 namespace eval {
 
 Score Evaluate(Board &board) {
-  return nnue::Evaluate(board.GetState(), board.GetAccumulator());
+  const Score network_eval =
+      nnue::Evaluate(board.GetState(), board.GetAccumulator());
+
+  const auto &state = board.GetState();
+
+  // Scale the score based on the number of material left
+  const int game_phase =
+      state.Knights().PopCount() + state.Bishops().PopCount() +
+      state.Rooks().PopCount() * 2 + state.Queens().PopCount() * 4;
+  const int material = std::min(game_phase, 24);
+
+  return network_eval * (56 + material) / 64;
 }
 
 bool StaticExchange(Move move, int threshold, const BoardState &state) {


### PR DESCRIPTION
```
Elo   | 8.33 +- 4.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5296 W: 1415 L: 1288 D: 2593
Penta | [27, 568, 1329, 699, 25]
https://chess.aronpetkovski.com/test/4286/
```