### PR TITLE
Reduce more in cut nodes

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -835,7 +835,7 @@ Score Search::PVSearch(Thread &thread,
     if (depth > 2 && moves_seen >= lmr_move_threshold) {
       int reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
       reduction += !in_pv_node - tt_was_in_pv;
-      reduction += cut_node;
+      reduction += 2 * cut_node;
       reduction -= gives_check;
       reduction -=
           stack->history_score /


### PR DESCRIPTION
```
Elo   | 2.02 +- 1.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 52500 W: 13600 L: 13295 D: 25605
Penta | [313, 6236, 12857, 6521, 323]
https://chess.aronpetkovski.com/test/4319/
```