### PR TITLE
Update Continuation History on LMR re-search

### DIFF
--- a/src/engine/search/history/continuation_history.h
+++ b/src/engine/search/history/continuation_history.h
@@ -18,20 +18,23 @@ class ContinuationHistory {
                    StackEntry *stack,
                    int depth,
                    MoveList &quiets) {
-    const Move move = stack->move;
-
     const int bonus = HistoryBonus(depth);
-    UpdateIndividualScore(state, move, bonus, stack - 1);
-    UpdateIndividualScore(state, move, bonus, stack - 2);
-    UpdateIndividualScore(state, move, bonus, stack - 4);
+    UpdateMoveScore(state, stack->move, bonus, stack);
 
     // Lower the score of the quiet moves that failed to raise alpha
     for (int i = 0; i < quiets.Size(); i++) {
       // Apply a linear dampening to the penalty as the depth increases
-      UpdateIndividualScore(state, quiets[i], -bonus, stack - 1);
-      UpdateIndividualScore(state, quiets[i], -bonus, stack - 2);
-      UpdateIndividualScore(state, quiets[i], -bonus, stack - 4);
+      UpdateMoveScore(state, quiets[i], -bonus, stack);
     }
+  }
+
+  void UpdateMoveScore(const BoardState &state,
+                       Move move,
+                       int bonus,
+                       StackEntry *stack) {
+    UpdateIndividualScore(state, move, bonus, stack - 1);
+    UpdateIndividualScore(state, move, bonus, stack - 2);
+    UpdateIndividualScore(state, move, bonus, stack - 4);
   }
 
   [[nodiscard]] ContinuationEntry *GetEntry(const BoardState &state,

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -876,7 +876,7 @@ Score Search::PVSearch(Thread &thread,
                         : score >= beta  ? history::HistoryBonus(new_depth)
                                          : 0;
         history.continuation_history->UpdateMoveScore(
-            state, move, bonus, stack);
+            board.GetStateHistory().Back(), move, bonus, stack);
       }
     }
 


### PR DESCRIPTION
```
Elo   | 2.97 +- 2.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 28758 W: 7200 L: 6954 D: 14604
Penta | [150, 3372, 7096, 3604, 157]
https://chess.aronpetkovski.com/test/4458/
```