### PR TITLE
Simplify out check extensions

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -811,11 +811,6 @@ Score Search::PVSearch(Thread &thread,
       }
     }
 
-    // Check Extensions: Integral's not yet strong enough to simplify this out
-    if (stack->in_check) {
-      ++extensions;
-    }
-
     // Set the currently searched move in the stack for continuation history
     stack->move = move;
     stack->capture_move = move.IsCapture(state);


### PR DESCRIPTION
```
Elo   | 3.70 +- 3.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 9856 W: 2564 L: 2459 D: 4833
Penta | [46, 1159, 2436, 1218, 69]
https://chess.aronpetkovski.com/test/4472/
```