### PR TITLE
Use Capture History in the MovePicker SEE threshold

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -744,7 +744,11 @@ Score Search::PVSearch(Thread &thread,
       // Static Exchange Evaluation (SEE) Pruning: Skip moves that lose too much
       // material
       const int see_threshold =
-          is_quiet ? see_quiet_thresh * depth : see_noisy_thresh * depth;
+          is_quiet
+              ? see_quiet_thresh * depth
+              : see_noisy_thresh * depth -
+                    std::clamp<int>(
+                        stack->history_score / 100, -100 * depth, 100 * depth);
       if (depth <= see_prune_depth && moves_seen >= 1 &&
           !eval::StaticExchange(move, see_threshold, state)) {
         continue;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -744,11 +744,8 @@ Score Search::PVSearch(Thread &thread,
       // Static Exchange Evaluation (SEE) Pruning: Skip moves that lose too much
       // material
       const int see_threshold =
-          is_quiet
-              ? see_quiet_thresh * depth
-              : see_noisy_thresh * depth -
-                    std::clamp<int>(
-                        stack->history_score / 100, -100 * depth, 100 * depth);
+          is_quiet ? see_quiet_thresh * depth
+                   : see_noisy_thresh * depth - stack->history_score / 150;
       if (depth <= see_prune_depth && moves_seen >= 1 &&
           !eval::StaticExchange(move, see_threshold, state)) {
         continue;


### PR DESCRIPTION
```
Elo   | 4.03 +- 2.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19384 W: 4973 L: 4748 D: 9663
Penta | [110, 2219, 4808, 2446, 109]
https://chess.aronpetkovski.com/test/4511/
```