### PR TITLE
Fix Continuation History LMR research bonus

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -871,7 +871,7 @@ Score Search::PVSearch(Thread &thread,
       score = -PVSearch<NodeType::kNonPV>(
           thread, new_depth, -alpha - 1, -alpha, stack + 1, !cut_node);
 
-      if (reduction != 0) {
+      if (reduction != 0 && is_quiet) {
         const int bonus = score <= alpha ? -history::HistoryBonus(new_depth)
                         : score >= beta  ? history::HistoryBonus(new_depth)
                                          : 0;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -744,7 +744,8 @@ Score Search::PVSearch(Thread &thread,
       // Static Exchange Evaluation (SEE) Pruning: Skip moves that lose too much
       // material
       const int see_threshold =
-          is_quiet ? see_quiet_thresh * depth : see_noisy_thresh * depth;
+          is_quiet ? see_quiet_thresh * depth
+                   : see_noisy_thresh * depth - stack->history_score / 150;
       if (depth <= see_prune_depth && moves_seen >= 1 &&
           !eval::StaticExchange(move, see_threshold, state)) {
         continue;


### PR DESCRIPTION
```
Elo   | 2.18 +- 3.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 14490 W: 3678 L: 3587 D: 7225
Penta | [82, 1695, 3595, 1796, 77]
https://chess.aronpetkovski.com/test/4512/
```