### PR TITLE
Double extensions depth increase

### DIFF
--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -39,12 +39,16 @@ Move MovePicker::Next() {
   if (stage_ == Stage::kGoodNoisys) {
     while (moves_idx_ < noisys_.Size()) {
       const auto move = SelectionSort(noisys_, moves_idx_);
-      const int score = noisys_[moves_idx_].score;
+      const auto score = noisys_[moves_idx_].score;
+      const auto history_score = history_.GetCaptureMoveScore(state, move);
 
       moves_idx_++;
 
-      const bool loses_material =
-          !eval::StaticExchange(move, see_threshold_, state);
+      const bool loses_material = !eval::StaticExchange(
+          move,
+          type_ != MovePickerType::kNoisy ? -history_score / 100
+                                          : see_threshold_,
+          state);
       if (!loses_material && !move.IsUnderPromotion()) {
         return move;
       }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -744,7 +744,8 @@ Score Search::PVSearch(Thread &thread,
       // Static Exchange Evaluation (SEE) Pruning: Skip moves that lose too much
       // material
       const int see_threshold =
-          is_quiet ? see_quiet_thresh * depth : see_noisy_thresh * depth;
+          is_quiet ? see_quiet_thresh * depth
+                   : see_noisy_thresh * depth - stack->history_score / 150;
       if (depth <= see_prune_depth && moves_seen >= 1 &&
           !eval::StaticExchange(move, see_threshold, state)) {
         continue;
@@ -872,7 +873,7 @@ Score Search::PVSearch(Thread &thread,
       score = -PVSearch<NodeType::kNonPV>(
           thread, new_depth, -alpha - 1, -alpha, stack + 1, !cut_node);
 
-      if (reduction != 0) {
+      if (reduction != 0 && is_quiet) {
         const int bonus = score <= alpha ? -history::HistoryBonus(new_depth)
                         : score >= beta  ? history::HistoryBonus(new_depth)
                                          : 0;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -793,6 +793,7 @@ Score Search::PVSearch(Thread &thread,
           if (!in_pv_node &&
               tt_move_excluded_score < new_beta - sing_double_margin) {
             extensions = 2;
+            depth += depth < 10;
           } else {
             extensions = 1;
           }


### PR DESCRIPTION
```
Elo   | 3.56 +- 2.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22634 W: 5811 L: 5579 D: 11244
Penta | [113, 2664, 5556, 2846, 138]
https://chess.aronpetkovski.com/test/4528/
```