### PR TITLE
Use enemy threats for quiet move ordering

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -443,12 +443,17 @@ void Board::CalculateThreats() {
 
   state_.threatened_by[kPawn] = move_gen::PawnAttacks(state_.Pawns(them), them);
 
+  state_.threatened_by[kKnight] = 0;
   for (Square square : state_.Knights(them)) {
     state_.threatened_by[kKnight] |= move_gen::KnightMoves(square);
   }
 
   const BitBoard queens = state_.Queens(them);
   const BitBoard occupied = state_.Occupied();
+
+  state_.threatened_by[kBishop] = 0;
+  state_.threatened_by[kQueen] = 0;
+  state_.threatened_by[kRook] = 0;
 
   for (Square square : state_.Bishops(them) | queens) {
     state_.threatened_by[(queens.IsSet(square) ? kQueen : kBishop)]

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -264,6 +264,7 @@ struct BoardState {
   std::array<U64, 2> non_pawn_keys;
   BitBoard checkers;
   BitBoard threats;
+  std::array<BitBoard, kNumPieceTypes> threatened_by;
   BitBoard pinned;
 };
 
@@ -317,6 +318,8 @@ class Board {
   void CalculateKingThreats();
 
   void CalculateThreats();
+
+  [[nodiscard]] BitBoard GetOpponentWinningCaptures() const;
 
  private:
   void HandleCastling(Move move);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -530,6 +530,9 @@ Score Search::PVSearch(Thread &thread,
         FlipColor(state.turn), prev_stack->move, prev_stack->threats, bonus);
   }
 
+  stack->threats = state.threats;
+  const bool no_piece_threats = (state.threats & state.Occupied(state.turn)) == 0;
+
   // This condition is dependent on if the side to move's static evaluation
   // has improved in the past two or four plies. It also used as a metric for
   // adjusting pruning thresholds
@@ -576,7 +579,7 @@ Score Search::PVSearch(Thread &thread,
     // Null Move Pruning: Forfeit a move to our opponent and cutoff if we still
     // have the advantage
     if (!(stack - 1)->move.IsNull() && stack->eval >= beta &&
-        stack->static_eval >= beta + 170 - 24 * depth &&
+        stack->static_eval >= beta + 170 - 24 * depth && no_piece_threats &&
         !stack->excluded_tt_move) {
       // Avoid null move pruning a position with high zugzwang potential
       const BitBoard non_pawn_king_pieces =
@@ -690,8 +693,6 @@ Score Search::PVSearch(Thread &thread,
   const int original_alpha = alpha;
   // Keep track of quiet and capture moves that failed to cause a beta cutoff
   MoveList quiets, captures;
-
-  stack->threats = state.threats;
 
   int moves_seen = 0;
   Score best_score = kScoreNone;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -531,7 +531,6 @@ Score Search::PVSearch(Thread &thread,
   }
 
   stack->threats = state.threats;
-  const bool no_piece_threats = (state.threats & state.Occupied(state.turn)) == 0;
 
   // This condition is dependent on if the side to move's static evaluation
   // has improved in the past two or four plies. It also used as a metric for
@@ -552,6 +551,8 @@ Score Search::PVSearch(Thread &thread,
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !stack->in_check && stack->eval < kTBWinInMaxPlyScore) {
+    const bool no_piece_threats = (state.threats & (state.Occupied(state.turn) ^ state.Pawns(state.turn))) == 0;
+
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= rev_fut_depth && !stack->excluded_tt_move &&

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -551,8 +551,6 @@ Score Search::PVSearch(Thread &thread,
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !stack->in_check && stack->eval < kTBWinInMaxPlyScore) {
-    const bool no_piece_threats = board.GetOpponentWinningCaptures() == 0;
-
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= rev_fut_depth && !stack->excluded_tt_move &&
@@ -580,7 +578,7 @@ Score Search::PVSearch(Thread &thread,
     // Null Move Pruning: Forfeit a move to our opponent and cutoff if we still
     // have the advantage
     if (!(stack - 1)->move.IsNull() && stack->eval >= beta &&
-        stack->static_eval >= beta + 170 - 24 * depth && no_piece_threats &&
+        stack->static_eval >= beta + 170 - 24 * depth &&
         !stack->excluded_tt_move) {
       // Avoid null move pruning a position with high zugzwang potential
       const BitBoard non_pawn_king_pieces =

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -551,7 +551,7 @@ Score Search::PVSearch(Thread &thread,
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !stack->in_check && stack->eval < kTBWinInMaxPlyScore) {
-    const bool no_piece_threats = (state.threats & (state.Occupied(state.turn) ^ state.Pawns(state.turn))) == 0;
+    const bool no_piece_threats = board.GetOpponentWinningCaptures() == 0;
 
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon


### PR DESCRIPTION
```
Elo   | 2.52 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 35586 W: 8914 L: 8656 D: 18016
Penta | [143, 4218, 8849, 4404, 179]
https://chess.aronpetkovski.com/test/4628/
```