### PR TITLE
Triple extensions

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -48,10 +48,9 @@ Tunable capt_hist_thresh_mult("capt_hist_thresh_mult", -1695, -3000, -250, 300);
 Tunable lmr_hist_div("lmr_hist_div", 11432, 5000, 20000, 750);
 Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 
-Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
-Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
-Tunable sing_double_margin("sing_double_margin", 15, 10, 40, 5);
-Tunable sing_triple_margin("sing_double_margin", 110, 10, 40, 5);
+Tunable se_depth("sing_ext_depth", 6, 6, 12, 1, true);
+Tunable se_double_margin("sing_double_margin", 15, 10, 40, 5);
+Tunable se_triple_margin("sing_triple_margin", 110, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -51,6 +51,7 @@ Tunable lmr_capt_hist_div("lmr_capt_hist_div", 11432, 5000, 20000, 750);
 Tunable sing_ext_depth("sing_ext_depth", 8, 6, 12, 1, true);
 Tunable sing_ext_margin("sing_ext_margin", 2.00, 1.0, 4.0, 0.5);
 Tunable sing_double_margin("sing_double_margin", 15, 10, 40, 5);
+Tunable sing_triple_margin("sing_double_margin", 110, 10, 40, 5);
 
 Tunable probcut_beta_delta("probcut_beta_delta", 250, 150, 350, 15);
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -790,10 +790,11 @@ Score Search::PVSearch(Thread &thread,
         // No move was able to beat the TT entries score, so we extend the TT
         // move's search
         if (tt_move_excluded_score < new_beta) {
-          // Double extend if the TT move is singular by a big margin
+          // Extend more if the TT move is singular by a big margin
           if (!in_pv_node &&
               tt_move_excluded_score < new_beta - sing_double_margin) {
-            extensions = 2;
+            extensions = 2 + (is_quiet && tt_move_excluded_score <
+                                              new_beta - sing_triple_margin);
             depth += depth < 10;
           } else {
             extensions = 1;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -767,7 +767,7 @@ Score Search::PVSearch(Thread &thread,
     // Singular Extensions: If a TT move exists and its score is accurate enough
     // (close enough in depth), we perform a reduced-depth search with the TT
     // move excluded to see if any other moves can beat it.
-    if (!in_root && depth >= 6 && move == tt_move &&
+    if (!in_root && depth >= se_depth && move == tt_move &&
         stack->ply < thread.root_depth * 2) {
       const bool is_accurate_tt_score =
           tt_entry->depth + 3 >= depth &&
@@ -792,9 +792,9 @@ Score Search::PVSearch(Thread &thread,
         if (tt_move_excluded_score < new_beta) {
           // Extend more if the TT move is singular by a big margin
           if (!in_pv_node &&
-              tt_move_excluded_score < new_beta - sing_double_margin) {
+              tt_move_excluded_score < new_beta - se_double_margin) {
             extensions = 2 + (is_quiet && tt_move_excluded_score <
-                                              new_beta - sing_triple_margin);
+                                              new_beta - se_triple_margin);
             depth += depth < 10;
           } else {
             extensions = 1;


### PR DESCRIPTION
```
Elo   | 1.76 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 63796 W: 15992 L: 15668 D: 32136
Penta | [275, 7635, 15795, 7877, 316]
https://chess.aronpetkovski.com/test/4654/
```
Should scale well at LTC.