### PR TITLE
No LMR on capture moves in PV nodes

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -835,8 +835,7 @@ Score Search::PVSearch(Thread &thread,
 
     // Late Move Reduction: Moves that are less likely to be good (due to the
     // move ordering) are searched at lower depths
-    const int lmr_move_threshold = 1 + in_root * 2;
-    if (depth > 2 && moves_seen >= lmr_move_threshold) {
+    if (depth > 2 && moves_seen >= 1 + in_root * 2 && !(in_pv_node && is_capture)) {
       reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
       reduction += !in_pv_node - tt_was_in_pv;
       reduction += 2 * cut_node;


### PR DESCRIPTION
```
Elo   | 1.61 +- 1.31 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 76734 W: 19419 L: 19063 D: 38252
Penta | [380, 9177, 18972, 9383, 455]
https://chess.aronpetkovski.com/test/4638/
```