### PR TITLE
Use corrected evaluation as a complexity metric in LMR

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -845,6 +845,7 @@ Score Search::PVSearch(Thread &thread,
           stack->history_score /
           static_cast<int>(is_quiet ? lmr_hist_div : lmr_capt_hist_div);
       reduction += !improving;
+      reduction -= std::abs(stack->static_eval - raw_static_eval) > 80;
 
       // Ensure the reduction doesn't give us a depth below 0
       reduction = std::clamp<int>(reduction, 0, new_depth - 1);


### PR DESCRIPTION
```
Elo   | 2.06 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 48484 W: 12138 L: 11850 D: 24496
Penta | [212, 5701, 12171, 5903, 255]
https://chess.aronpetkovski.com/test/4678/
```