### PR TITLE
Simplify away evaluation material scaling

### DIFF
--- a/src/engine/evaluation/evaluation.cc
+++ b/src/engine/evaluation/evaluation.cc
@@ -5,15 +5,7 @@
 namespace eval {
 
 Score Evaluate(Board &board) {
-  const auto network_eval = nnue::Evaluate(board);
-  const auto &state = board.GetState();
-
-  // Scale the score based on the number of material left
-  const int phase =
-      state.Knights().PopCount() * 3 + state.Bishops().PopCount() * 3 +
-      state.Rooks().PopCount() * 5 + state.Queens().PopCount() * 12;
-
-  return network_eval * (200 + phase) / 256;
+  return nnue::Evaluate(board);
 }
 
 bool StaticExchange(Move move, int threshold, const BoardState &state) {


### PR DESCRIPTION
```
Elo   | 4.55 +- 4.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 8558 W: 2232 L: 2120 D: 4206
Penta | [48, 1017, 2077, 1049, 88]
https://chess.aronpetkovski.com/test/4799/
```