### PR TITLE
Use move history score in futility pruning

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -734,7 +734,9 @@ Score Search::PVSearch(Thread &thread,
 
       // Futility Pruning: Skip (futile) quiet moves at near-leaf nodes when
       // there's a low chance to raise alpha
-      const int futility_margin = fut_margin_base + fut_margin_mult * lmr_depth;
+      const int futility_margin = fut_margin_base +
+                                  fut_margin_mult * lmr_depth +
+                                  stack->history_score / 64;
       if (lmr_depth <= fut_prune_depth && !stack->in_check && is_quiet &&
           stack->eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
@@ -836,7 +838,8 @@ Score Search::PVSearch(Thread &thread,
 
     // Late Move Reduction: Moves that are less likely to be good (due to the
     // move ordering) are searched at lower depths
-    if (depth > 2 && moves_seen >= 1 + in_root * 2 && !(in_pv_node && is_capture)) {
+    if (depth > 2 && moves_seen >= 1 + in_root * 2 &&
+        !(in_pv_node && is_capture)) {
       reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
       reduction += !in_pv_node - tt_was_in_pv;
       reduction += 2 * cut_node;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -736,7 +736,7 @@ Score Search::PVSearch(Thread &thread,
       // there's a low chance to raise alpha
       const int futility_margin = fut_margin_base +
                                   fut_margin_mult * lmr_depth +
-                                  stack->history_score / 64;
+                                  stack->history_score / 100;
       if (lmr_depth <= fut_prune_depth && !stack->in_check && is_quiet &&
           stack->eval + futility_margin < alpha) {
         move_picker.SkipQuiets();


### PR DESCRIPTION
```
Elo   | 1.85 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 62492 W: 16166 L: 15833 D: 30493
Penta | [450, 7470, 15098, 7753, 475]
https://chess.aronpetkovski.com/test/4822/
```