### PR TITLE
Stricter TT cutoff conditions in PVS

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -428,7 +428,8 @@ Score Search::PVSearch(Thread &thread,
 
     // Saved scores from non-PV nodes must fall within the current alpha/beta
     // window to allow early cutoff
-    if (!in_pv_node && can_use_tt_eval && tt_entry->depth >= depth) {
+    if (!in_pv_node && can_use_tt_eval &&
+        (cut_node || tt_entry->score <= alpha) && tt_entry->depth >= depth) {
       return TranspositionTableEntry::CorrectScore(tt_entry->score, stack->ply);
     }
   }


### PR DESCRIPTION
Patch from Berserk.
```
Elo   | 1.10 +- 0.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 231014 W: 59505 L: 58773 D: 112736
Penta | [1710, 27618, 56120, 28348, 1711]
https://chess.aronpetkovski.com/test/4938/
```