### PR TITLE
Fix scores being 0 when hard cutoff

### DIFF
--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -16,7 +16,8 @@ class CorrectionHistory {
       : non_pawn_table_({}),
         pawn_table_({}),
         minor_table_({}),
-        major_table_({}) {}
+        major_table_({}),
+        continuation_table_({}) {}
 
   void UpdateScore(const BoardState &state,
                    StackEntry *stack,
@@ -56,9 +57,21 @@ class CorrectionHistory {
       non_pawn_table_score =
           UpdateTableScore(non_pawn_table_score, weight, scaled_bonus);
     }
+
+    // Update continuation table scores
+    if (stack->ply >= 2 && (stack - 1)->move && (stack - 2)->move) {
+      auto &continuation_table_score =
+          continuation_table_[state.turn][(stack - 2)->moved_piece]
+                             [(stack - 2)->move.GetTo()]
+                             [(stack - 1)->moved_piece]
+                             [(stack - 1)->move.GetTo()];
+      continuation_table_score =
+          UpdateTableScore(continuation_table_score, weight, scaled_bonus);
+    }
   }
 
   [[nodiscard]] Score CorrectStaticEval(const BoardState &state,
+                                        StackEntry *stack,
                                         Score static_eval) const {
     const Score pawn_correction =
         pawn_table_[state.turn][GetPawnTableIndex(state)];
@@ -72,10 +85,19 @@ class CorrectionHistory {
         minor_table_[state.turn][GetMinorTableIndex(state)];
     const I32 major_correction =
         major_table_[state.turn][GetMajorTableIndex(state)];
+    const I32 continuation_correction = [&]() -> I32 {
+      if (stack->ply >= 2 && (stack - 1)->move && (stack - 2)->move) {
+        return continuation_table_[state.turn][(stack - 2)->moved_piece]
+                                  [(stack - 2)->move.GetTo()]
+                                  [(stack - 1)->moved_piece]
+                                  [(stack - 1)->move.GetTo()];
+      }
+      return 0;
+    }();
     const I32 correction =
         pawn_correction +
         (non_pawn_white_correction + non_pawn_black_correction) / 2 +
-        (minor_correction + major_correction) / 2;
+        (minor_correction + major_correction) / 2 + continuation_correction;
     const I32 adjusted_score =
         static_cast<I32>(static_eval) +
         correction / static_cast<int>(corr_history_scale);
@@ -137,6 +159,8 @@ class CorrectionHistory {
   MultiArray<Score, kNumColors, 16384> minor_table_;
   MultiArray<Score, kNumColors, 16384> major_table_;
   MultiArray<Score, kNumColors, kNumColors, 16384> non_pawn_table_;
+  MultiArray<Score, 2, kNumPieceTypes, 64, kNumPieceTypes, 64>
+      continuation_table_;
 };
 
 }  // namespace search::history

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -86,14 +86,15 @@ void Search::IterativeDeepening(Thread &thread) {
       const Score new_score = PVSearch<NodeType::kPV>(
           thread, depth - fail_high_count, alpha, beta, root_stack, false);
 
+      if (root_stack->best_move) {
+        best_move = root_stack->best_move;
+      }
+
       if (ShouldQuit(thread)) {
         break;
       }
 
-      if (root_stack->best_move) {
-        best_move = root_stack->best_move;
-        score = new_score;
-      }
+      score = new_score;
 
       if (score <= alpha) {
         // Narrow beta to increase the chance of a fail high

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -64,6 +64,7 @@ struct StackEntry {
   // Currently searched move at this ply
   Move move;
   bool capture_move;
+  PieceType moved_piece;
   // The excluded TT move when performing singular extensions
   Move excluded_tt_move;
   // Continuation history entry for this move


### PR DESCRIPTION
```
Elo   | -0.10 +- 3.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.64 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 10664 W: 2716 L: 2719 D: 5229
Penta | [59, 1160, 2898, 1155, 60]
https://chess.aronpetkovski.com/test/4996/
```