### PR TITLE
Store to TT during QS stand-pat cutoff

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -271,6 +271,20 @@ Score Search::QuiescentSearch(Thread &thread,
 
     // Early beta cutoff
     if (best_score >= beta) {
+      // Save the static eval in the TT if we have nothing yet
+      if (!tt_hit) {
+        const TranspositionTableEntry new_tt_entry(
+            state.zobrist_key,
+            tt_depth,
+            TranspositionTableEntry::kNone,
+            kScoreNone,
+            raw_static_eval,
+            Move::NullMove(),
+            tt_was_in_pv);
+        transposition_table_.Save(
+            tt_entry, new_tt_entry, state.zobrist_key, stack->ply);
+      }
+
       return best_score;
     }
 


### PR DESCRIPTION
```
Elo   | 4.90 +- 2.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15588 W: 4148 L: 3928 D: 7512
Penta | [92, 1827, 3762, 1995, 118]
https://chess.aronpetkovski.com/test/5223/
```