### PR TITLE
Utilize improving heuristic in NMP

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -607,7 +607,9 @@ Score Search::PVSearch(Thread &thread,
         const int eval_reduction =
             std::min<int>(2, (stack->eval - beta) / kNullMoveRe);
         const int reduction = std::clamp<int>(
-            depth / kNullMoveRf + kNullMoveRb + eval_reduction, 0, depth);
+            depth / kNullMoveRf + kNullMoveRb + eval_reduction + improving,
+            0,
+            depth);
 
         board.MakeNullMove();
         const Score score = -PVSearch<NodeType::kNonPV>(


### PR DESCRIPTION
```
Elo   | 3.64 +- 2.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22076 W: 5813 L: 5582 D: 10681
Penta | [139, 2497, 5525, 2748, 129]
https://chess.aronpetkovski.com/test/5232/
```