### PR TITLE
Increase history bonus & penalty when `alpha > beta + 50`

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -948,14 +948,15 @@ Score Search::PVSearch(Thread &thread,
 
         alpha = score;
         if (alpha >= beta) {
+          const int history_depth = depth + (alpha > beta + 50);
           if (is_quiet) {
             stack->AddKillerMove(move);
             history.quiet_history->UpdateScore(
-                state, stack, depth, stack->threats, quiets);
+                state, stack, history_depth, stack->threats, quiets);
             history.continuation_history->UpdateScore(
-                state, stack, depth, quiets);
+                state, stack, history_depth, quiets);
           } else if (is_capture) {
-            history.capture_history->UpdateScore(state, stack, depth);
+            history.capture_history->UpdateScore(state, stack, history_depth);
           }
           // Beta cutoff: The opponent had a better move earlier in the tree
           break;


### PR DESCRIPTION
```
Elo   | 2.79 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32046 W: 8323 L: 8066 D: 15657
Penta | [183, 3748, 7920, 3973, 199]
https://chess.aronpetkovski.com/test/5257/
```