### PR TITLE
Tweak negative extensions

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -843,7 +843,9 @@ Score Search::PVSearch(Thread &thread,
         }
         // Negative Extensions: Search less since the TT move was not singular,
         // and it might cause a beta cutoff again.
-        else if (tt_entry->score >= beta || cut_node) {
+        else if (tt_entry->score >= beta) {
+          extensions = -2 + in_pv_node;
+        } else if (cut_node) {
           extensions = -1;
         }
       }


### PR DESCRIPTION
```
Elo   | 1.98 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 52952 W: 13511 L: 13209 D: 26232
Penta | [293, 6246, 13102, 6536, 299]
https://chess.aronpetkovski.com/test/5282/
```