### PR TITLE
Reduce killer moves less

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -883,6 +883,8 @@ Score Search::PVSearch(Thread &thread,
       reduction += !improving;
       reduction -=
           std::abs(stack->static_eval - raw_static_eval) > kLmrComplexityDiff;
+      reduction -=
+          move == stack->killer_moves[0] || move == stack->killer_moves[1];
 
       // Ensure the reduction doesn't give us a depth below 0
       reduction = std::clamp<int>(reduction, 0, new_depth - 1);


### PR DESCRIPTION
```
Elo   | 2.65 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33260 W: 8468 L: 8214 D: 16578
Penta | [149, 3911, 8286, 4105, 179]
https://chess.aronpetkovski.com/test/5297/
```