### PR TITLE
Split captures using capture history in ProbCut

### DIFF
--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -74,10 +74,7 @@ Move MovePicker::Next() {
       moves_idx_++;
 
       const bool loses_material = !eval::StaticExchange(
-          move,
-          type_ != MovePickerType::kNoisy ? -history_score / kSeeNoisyHistoryDiv
-                                          : see_threshold_,
-          state);
+          move, see_threshold_ - history_score / kSeeNoisyHistoryDiv, state);
       if (!loses_material && !move.IsUnderPromotion()) {
         return move;
       }


### PR DESCRIPTION
```
Elo   | 1.44 +- 1.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.62 (-2.25, 2.89) [0.00, 3.00]
Games | N: 53340 W: 13490 L: 13269 D: 26581
Penta | [239, 6392, 13201, 6585, 253]
https://chess.aronpetkovski.com/test/5300/
```