### PR TITLE
Use quiet history for SEE pruning

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -45,7 +45,7 @@ TUNABLE(kFutMarginHistDiv, 147, 32, 256, false);
 TUNABLE(kSeePruneDepth, 8, 6, 12, true);
 TUNABLE(kSeeQuietThresh, -62, -100, -20, false);
 TUNABLE(kSeeNoisyThresh, -115, -200, -50, false);
-TUNABLE(kSeeNoisyHistDiv, 151, 32, 256, false);
+TUNABLE(kSeePruneHistDiv, 151, 32, 256, false);
 
 TUNABLE(kHistPruneDepth, 5, 3, 8, true);
 TUNABLE(kHistThreshBase, -481, -1000, 500, false);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -1,8 +1,8 @@
 #include "search.h"
 
 #include <algorithm>
-#include <thread>
 #include <numeric>
+#include <thread>
 
 #include "../uci/reporter.h"
 #include "constants.h"
@@ -786,10 +786,9 @@ Score Search::PVSearch(Thread &thread,
 
       // Static Exchange Evaluation (SEE) Pruning: Skip moves that lose too much
       // material
-      const int see_threshold = is_quiet
-                                  ? kSeeQuietThresh * depth
-                                  : kSeeNoisyThresh * depth -
-                                        stack->history_score / kSeeNoisyHistDiv;
+      const int see_threshold =
+          (is_quiet ? kSeeQuietThresh * depth : kSeeNoisyThresh * depth) -
+          stack->history_score / kSeePruneHistDiv;
       if (depth <= kSeePruneDepth && moves_seen >= 1 &&
           !eval::StaticExchange(move, see_threshold, state)) {
         continue;


### PR DESCRIPTION
```
Elo   | 1.05 +- 0.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.03 (-2.25, 2.89) [0.00, 3.00]
Games | N: 187340 W: 47938 L: 47370 D: 92032
Penta | [1249, 22453, 45700, 23017, 1251]
https://chess.aronpetkovski.com/test/5481/
```