### PR TITLE
Use static evaluation for futility pruning

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -780,7 +780,7 @@ Score Search::PVSearch(Thread &thread,
       const int futility_margin = kFutMarginBase + kFutMarginMult * lmr_depth +
                                   stack->history_score / kFutMarginHistDiv;
       if (lmr_depth <= kFutPruneDepth && !stack->in_check && is_quiet &&
-          stack->eval + futility_margin < alpha) {
+          stack->static_eval + futility_margin < alpha) {
         move_picker.SkipQuiets();
         continue;
       }


### PR DESCRIPTION
```
Elo   | 2.64 +- 1.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33846 W: 8609 L: 8352 D: 16885
Penta | [159, 4023, 8344, 4196, 201]
https://chess.aronpetkovski.com/test/5599/
```