### PR TITLE
Increase SE depth reduction

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -818,7 +818,7 @@ Score Search::PVSearch(Thread &thread,
           std::abs(tt_entry->score) < kTBWinInMaxPlyScore;
 
       if (is_accurate_tt_score) {
-        const int reduced_depth = 5 * (depth - 1) / 8;
+        const int reduced_depth = 3 * (depth - 1) / 8;
         const Score new_beta = tt_entry->score - depth;
 
         stack->excluded_tt_move = tt_move;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -819,7 +819,7 @@ Score Search::PVSearch(Thread &thread,
 
       if (is_accurate_tt_score) {
         const int reduced_depth = (depth - 1) / 2;
-        const Score new_beta = tt_entry->score - depth;
+        const Score new_beta = tt_entry->score - 5 * depth / 8;
 
         stack->excluded_tt_move = tt_move;
         const Score tt_move_excluded_score = PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -818,8 +818,8 @@ Score Search::PVSearch(Thread &thread,
           std::abs(tt_entry->score) < kTBWinInMaxPlyScore;
 
       if (is_accurate_tt_score) {
-        const int reduced_depth = (depth - 1) / 2;
-        const Score new_beta = tt_entry->score - 5 * depth / 8;
+        const int reduced_depth = 5 * (depth - 1) / 8;
+        const Score new_beta = tt_entry->score - depth;
 
         stack->excluded_tt_move = tt_move;
         const Score tt_move_excluded_score = PVSearch<NodeType::kNonPV>(


### PR DESCRIPTION
STC
```
Elo   | 2.56 +- 1.91 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 35122 W: 8583 L: 8324 D: 18215
Penta | [163, 4095, 8763, 4400, 140]
https://chess.aronpetkovski.com/test/5708/
```
LTC
```
Elo   | 1.54 +- 1.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 50608 W: 12224 L: 12000 D: 26384
Penta | [86, 5911, 13071, 6165, 71]
https://chess.aronpetkovski.com/test/5713/
```