### PR TITLE
Scale evaluation based on material

### DIFF
--- a/src/engine/evaluation/evaluation.cc
+++ b/src/engine/evaluation/evaluation.cc
@@ -8,11 +8,13 @@ Score Evaluate(Board &board) {
   const auto network_eval = nnue::Evaluate(board);
 
   const auto &state = board.GetState();
-  const int phase =
-      3 * state.Knights().PopCount() + 3 * state.Bishops().PopCount() +
-      5 * state.Rooks().PopCount() + 12 * state.Queens().PopCount();
+  const auto material_phase =
+      kSeePieceScores[kKnight] * state.Knights().PopCount() +
+      kSeePieceScores[kBishop] * state.Bishops().PopCount() +
+      kSeePieceScores[kRook] * state.Rooks().PopCount() +
+      kSeePieceScores[kQueen] * state.Queens().PopCount();
 
-  return network_eval * (200 + phase) / 256;
+  return network_eval * (26500 + material_phase) / 32768;
 }
 
 bool StaticExchange(Move move, int threshold, const BoardState &state) {

--- a/src/engine/evaluation/evaluation.cc
+++ b/src/engine/evaluation/evaluation.cc
@@ -5,7 +5,14 @@
 namespace eval {
 
 Score Evaluate(Board &board) {
-  return nnue::Evaluate(board);
+  const auto network_eval = nnue::Evaluate(board);
+
+  const auto &state = board.GetState();
+  const int phase =
+      3 * state.Knights().PopCount() + 3 * state.Bishops().PopCount() +
+      5 * state.Rooks().PopCount() + 12 * state.Queens().PopCount();
+
+  return network_eval * (200 + phase) / 256;
 }
 
 bool StaticExchange(Move move, int threshold, const BoardState &state) {


### PR DESCRIPTION
Re-introduced into Integral using Stormphrax formula
```
Elo   | 3.77 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20660 W: 5185 L: 4961 D: 10514
Penta | [113, 2342, 5156, 2646, 73]
https://chess.aronpetkovski.com/test/5758/
```