### PR TITLE
Triple extend more often

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -62,7 +62,7 @@ TUNABLE(kDoShallowerBase, 5, 0, 30, false);
 
 TUNABLE(kSeDepth, 6, 6, 12, true);
 TUNABLE(kSeDoubleMargin, 13, 0, 30, false);
-TUNABLE(kSeTripleMargin, 104, 30, 250, false);
+TUNABLE(kSeTripleMargin, 80, 30, 250, false);
 TUNABLE(kSeDepthExtensionDepth, 11, 0, 15, false);
 
 TUNABLE(kProbcutDepth, 5, 1, 10, false);


### PR DESCRIPTION
```
Elo   | 1.48 +- 1.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 60290 W: 14856 L: 14600 D: 30834
Penta | [334, 7141, 14911, 7453, 306]
https://chess.aronpetkovski.com/test/5768/
```