### PR TITLE
Switch to using I16's for histories

### DIFF
--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -11,22 +11,20 @@ TUNABLE(kHistBonusScale, 137, 65, 260, false);
 TUNABLE(kHistPenaltyScale, 150, 65, 260, false);
 TUNABLE(kHistBonusMaxBonus, 1188, 580, 2318, true);
 
-static int HistoryBonus(int depth,
-                        int scale = kHistBonusScale,
-                        int max_bonus = kHistBonusMaxBonus) {
-  return std::clamp(scale * depth, -max_bonus, max_bonus);
+static I16 HistoryBonus(I16 depth,
+                        I16 scale = kHistBonusScale,
+                        I16 max_bonus = kHistBonusMaxBonus) {
+  return std::clamp<I16>(scale * depth, -max_bonus, max_bonus);
 }
 
-static int HistoryPenalty(int depth,
-                        int scale = kHistPenaltyScale,
-                        int max_bonus = kHistBonusMaxBonus) {
-  return std::clamp(-scale * depth, -max_bonus, max_bonus);
+static I16 HistoryPenalty(I16 depth,
+                          I16 scale = kHistPenaltyScale,
+                          I16 max_bonus = kHistBonusMaxBonus) {
+  return std::clamp<I16>(-scale * depth, -max_bonus, max_bonus);
 }
 
 // Linear interpolation of the bonus and maximum score
-static int ScaleBonus(I32 score,
-                      int bonus,
-                      int gravity = kHistBonusGravity) {
+static I16 ScaleBonus(I16 score, I16 bonus, I16 gravity = kHistBonusGravity) {
   return bonus - score * std::abs(bonus) / gravity;
 }
 

--- a/src/engine/search/history/capture_history.h
+++ b/src/engine/search/history/capture_history.h
@@ -1,5 +1,5 @@
-#ifndef INTEGRAL_CAPTURE_HISTORY_H
-#define INTEGRAL_CAPTURE_HISTORY_H
+#ifndef I16EGRAL_CAPTURE_HISTORY_H
+#define I16EGRAL_CAPTURE_HISTORY_H
 
 #include "../../../utils/multi_array.h"
 #include "../stack.h"
@@ -11,33 +11,33 @@ class CaptureHistory {
  public:
   CaptureHistory() : table_({}) {}
 
-  void UpdateScore(const BoardState &state, StackEntry *stack, int depth) {
-    const int bonus = HistoryBonus(depth);
+  void UpdateScore(const BoardState &state, StackEntry *stack, I16 depth) {
+    const I16 bonus = HistoryBonus(depth);
     // Apply a linear dampening to the bonus as the depth increases
-    int &score = table_[state.turn][stack->move.GetFrom()][stack->move.GetTo()];
+    I16 &score = table_[state.turn][stack->move.GetFrom()][stack->move.GetTo()];
     score += ScaleBonus(score, bonus);
   }
 
-  void Penalize(const BoardState &state, int depth, MoveList &captures) {
-    const int penalty = HistoryPenalty(depth);
+  void Penalize(const BoardState &state, I16 depth, MoveList &captures) {
+    const I16 penalty = HistoryPenalty(depth);
     // Lower the score of the capture moves that failed to raise alpha
-    for (int i = 0; i < captures.Size(); i++) {
+    for (I16 i = 0; i < captures.Size(); i++) {
       const Move bad_capture = captures[i];
       // Apply a linear dampening to the penalty as the depth increases
-      int &bad_capture_score =
+      I16 &bad_capture_score =
           table_[state.turn][bad_capture.GetFrom()][bad_capture.GetTo()];
       bad_capture_score += ScaleBonus(bad_capture_score, penalty);
     }
   }
 
-  [[nodiscard]] int GetScore(const BoardState &state, Move move) const {
+  [[nodiscard]] I16 GetScore(const BoardState &state, Move move) const {
     return table_[state.turn][move.GetFrom()][move.GetTo()];
   }
 
  private:
-  MultiArray<int, kNumColors, kSquareCount, kSquareCount> table_;
+  MultiArray<I16, kNumColors, kSquareCount, kSquareCount> table_;
 };
 
 }  // namespace search::history
 
-#endif  // INTEGRAL_CAPTURE_HISTORY_H
+#endif  // I16EGRAL_CAPTURE_HISTORY_H

--- a/src/engine/search/history/continuation_history.h
+++ b/src/engine/search/history/continuation_history.h
@@ -8,7 +8,7 @@
 namespace search::history {
 
 using ContinuationEntry =
-    MultiArray<I32, kNumColors, kNumPieceTypes, kSquareCount>;
+    MultiArray<I16, kNumColors, kNumPieceTypes, kSquareCount>;
 
 class ContinuationHistory {
  public:
@@ -16,13 +16,13 @@ class ContinuationHistory {
 
   void UpdateScore(const BoardState &state,
                    StackEntry *stack,
-                   int depth,
+                   I16 depth,
                    MoveList &quiets) {
     const int bonus = HistoryBonus(depth);
     UpdateMoveScore(state, stack->move, bonus, stack);
 
     // Lower the score of the quiet moves that failed to raise alpha
-    const int penalty = HistoryPenalty(depth);
+    const I16 penalty = HistoryPenalty(depth);
     for (int i = 0; i < quiets.Size(); i++) {
       // Apply a linear dampening to the penalty as the depth increases
       UpdateMoveScore(state, quiets[i], penalty, stack);
@@ -31,7 +31,7 @@ class ContinuationHistory {
 
   void UpdateMoveScore(const BoardState &state,
                        Move move,
-                       int bonus,
+                       I16 bonus,
                        StackEntry *stack) {
     UpdateIndividualScore(state, move, bonus, stack - 1);
     UpdateIndividualScore(state, move, bonus, stack - 2);
@@ -75,7 +75,7 @@ class ContinuationHistory {
     auto &entry =
         *reinterpret_cast<ContinuationEntry *>(stack->continuation_entry);
 
-    int &score = entry[state.turn][piece][to];
+    I16 &score = entry[state.turn][piece][to];
     score += ScaleBonus(score, bonus);
   }
 

--- a/src/engine/search/history/quiet_history.h
+++ b/src/engine/search/history/quiet_history.h
@@ -11,25 +11,25 @@ class QuietHistory {
  public:
   QuietHistory() : table_({}) {}
 
-  void UpdateMoveScore(Color turn, Move move, BitBoard threats, int bonus) {
+  void UpdateMoveScore(Color turn, Move move, BitBoard threats, I16 bonus) {
     // Apply a linear dampening to the bonus as the depth increases
-    int &score =
+    I16 &score =
         table_[turn][move.GetFrom()][move.GetTo()][ThreatIndex(move, threats)];
     score += ScaleBonus(score, bonus);
   }
 
   void UpdateScore(const BoardState &state,
                    StackEntry *stack,
-                   int depth,
+                   I16 depth,
                    BitBoard threats,
                    MoveList &quiets) {
-    const int bonus = HistoryBonus(depth);
+    const I16 bonus = HistoryBonus(depth);
 
     // Apply a linear dampening to the bonus as the depth increases
     UpdateMoveScore(state.turn, stack->move, threats, bonus);
 
     // Lower the score of the quiet moves that failed to raise alpha (gravity)
-    const int penalty = HistoryPenalty(depth);
+    const I16 penalty = HistoryPenalty(depth);
     for (int i = 0; i < quiets.Size(); i++) {
       UpdateMoveScore(state.turn, quiets[i], threats, penalty);
     }
@@ -48,7 +48,7 @@ class QuietHistory {
   }
 
  private:
-  MultiArray<int, kNumColors, kSquareCount, kSquareCount, 4> table_;
+  MultiArray<I16, kNumColors, kSquareCount, kSquareCount, 4> table_;
 };
 
 }  // namespace search::history


### PR DESCRIPTION
```
Elo   | 4.53 +- 5.44 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 0.79 (-2.25, 2.89) [0.00, 3.00]
Games | N: 4682 W: 1212 L: 1151 D: 2319
Penta | [36, 516, 1185, 559, 45]
https://chess.aronpetkovski.com/test/5766/
```