### PR TITLE
RFP less often when opponent has a guaranteed winning capture

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -581,13 +581,16 @@ Score Search::PVSearch(Thread &thread,
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !stack->in_check && stack->eval < kTBWinInMaxPlyScore) {
+    const bool opponent_easy_capture = board.GetOpponentWinningCaptures() != 0;
+
     // Reverse (Static) Futility Pruning: Cutoff if we think the position can't
     // fall below beta anytime soon
     if (depth <= kRevFutDepth && !stack->excluded_tt_move &&
         stack->eval >= beta) {
       const int futility_margin =
           depth * kRevFutMargin -
-          static_cast<int>(improving * 1.5 * kRevFutMargin) +
+          static_cast<int>((improving && !opponent_easy_capture) * 1.5 *
+                           kRevFutMargin) +
           (stack - 1)->history_score / kRevFutHistoryDiv;
       if (stack->eval - std::max(futility_margin, 20) >= beta) {
         // Return (eval + beta) / 2 as a balanced score: higher than the beta


### PR DESCRIPTION
```
Elo   | 2.80 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31240 W: 7815 L: 7563 D: 15862
Penta | [155, 3676, 7731, 3878, 180]
https://chess.aronpetkovski.com/test/5793/
```