### PR TITLE
TT cutoff depth tweak

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -457,7 +457,7 @@ Score Search::PVSearch(Thread &thread,
   // window to allow early cutoff
   if (!stack->excluded_tt_move && !in_pv_node && can_use_tt_eval &&
       (cut_node || tt_entry->score <= alpha) &&
-      tt_entry->depth > depth + (tt_entry->score <= beta)) {
+      tt_entry->depth > depth - (tt_entry->score <= beta)) {
     return TranspositionTableEntry::CorrectScore(tt_entry->score, stack->ply);
   }
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -456,7 +456,8 @@ Score Search::PVSearch(Thread &thread,
   // Saved scores from non-PV nodes must fall within the current alpha/beta
   // window to allow early cutoff
   if (!stack->excluded_tt_move && !in_pv_node && can_use_tt_eval &&
-      (cut_node || tt_entry->score <= alpha) && tt_entry->depth >= depth) {
+      (cut_node || tt_entry->score <= alpha) &&
+      tt_entry->depth > depth + (tt_entry->score <= beta)) {
     return TranspositionTableEntry::CorrectScore(tt_entry->score, stack->ply);
   }
 


### PR DESCRIPTION
```
Elo   | 1.76 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 65792 W: 16356 L: 16022 D: 33414
Penta | [366, 7828, 16158, 8194, 350]
https://chess.aronpetkovski.com/test/5786/
```