### PR TITLE
Fail-soft multicut

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -847,8 +847,9 @@ Score Search::PVSearch(Thread &thread,
         // Multi-cut: The singular search had a beta cutoff, indicating that the
         // TT move was not singular. Therefore, we prune if the same score would
         // cause a cutoff based on our current search window
-        else if (new_beta >= beta) {
-          return new_beta;
+        else if (tt_move_excluded_score >= beta &&
+                 std::abs(tt_move_excluded_score) < kTBWinInMaxPlyScore) {
+          return tt_move_excluded_score;
         }
         // Negative Extensions: Search less since the TT move was not singular,
         // and it might cause a beta cutoff again.


### PR DESCRIPTION
```
Elo   | 1.11 +- 1.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.65 (-2.25, 2.89) [0.00, 3.00]
Games | N: 113190 W: 28058 L: 27695 D: 57437
Penta | [612, 13463, 28142, 13706, 672]
https://chess.aronpetkovski.com/test/5828/
```