### PR TITLE
Reduce after fail-lows in mid-depth search

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -657,7 +657,7 @@ Score Search::PVSearch(Thread &thread,
       if (depth >= kProbcutDepth && std::abs(beta) < kTBWinInMaxPlyScore &&
           (!tt_hit || tt_entry->depth + 3 < depth ||
            tt_entry->score >= pc_beta)) {
-        const int pc_see = pc_beta - raw_static_eval;
+        const int pc_see = pc_beta - stack->static_eval;
         const Move pc_tt_move = eval::StaticExchange(tt_move, pc_see, state)
                                   ? tt_move
                                   : Move::NullMove();


### PR DESCRIPTION
Idea from SF
```
Elo   | 2.71 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32188 W: 8061 L: 7810 D: 16317
Penta | [146, 3775, 8005, 4018, 150]
https://chess.aronpetkovski.com/test/5914/
```