### PR TITLE
Reduce if an alpha raise didn't cause a cutoff

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -978,6 +978,9 @@ Score Search::PVSearch(Thread &thread,
           }
           // Beta cutoff: The opponent had a better move earlier in the tree
           break;
+        } else if (depth > 4 && depth < 10 && beta < kTBWinInMaxPlyScore &&
+                   alpha > -kTBWinInMaxPlyScore) {
+          --depth;
         }
       }
     }


### PR DESCRIPTION
Idea from SF
```
Elo   | 2.71 +- 2.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32188 W: 8061 L: 7810 D: 16317
Penta | [146, 3775, 8005, 4018, 150]
https://chess.aronpetkovski.com/test/5914/
```