### PR TITLE
Fix not setting history score in ProbCut

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -684,6 +684,10 @@ Score Search::PVSearch(Thread &thread,
           stack->capture_move = move.IsCapture(state);
           stack->continuation_entry =
               history.continuation_history->GetEntry(state, move);
+          stack->history_score = move.IsCapture(state)
+                                   ? history.GetCaptureMoveScore(state, move)
+                                   : history.GetQuietMoveScore(
+                                         state, move, stack->threats, stack);
 
           const int probcut_depth = depth - 3;
 


### PR DESCRIPTION
Good enough
```
Elo   | 0.96 +- 4.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.73 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 5810 W: 1439 L: 1423 D: 2948
Penta | [29, 683, 1463, 703, 27]
https://chess.aronpetkovski.com/test/5961/
```