### PR TITLE
Tweak RFP margin depending on opponent's evaluation trend

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -595,7 +595,7 @@ Score Search::PVSearch(Thread &thread,
       const int improving_margin =
           (improving && !opponent_easy_capture) * 1.5 * kRevFutMargin;
       const int futility_margin =
-          depth * kRevFutMargin - improving_margin - 20 * opponent_worsening -
+          depth * kRevFutMargin - improving_margin - 20 * opponent_worsening +
           (stack - 1)->history_score / kRevFutHistoryDiv;
       if (stack->eval - std::max(futility_margin, 20) >= beta) {
         // Return (eval + beta) / 2 as a balanced score: higher than the beta

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -595,7 +595,7 @@ Score Search::PVSearch(Thread &thread,
       const int improving_margin =
           (improving && !opponent_easy_capture) * 1.5 * kRevFutMargin;
       const int futility_margin =
-          depth * kRevFutMargin - improving_margin - 20 * opponent_worsening +
+          depth * kRevFutMargin - improving_margin - 15 * opponent_worsening +
           (stack - 1)->history_score / kRevFutHistoryDiv;
       if (stack->eval - std::max(futility_margin, 20) >= beta) {
         // Return (eval + beta) / 2 as a balanced score: higher than the beta

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -567,6 +567,9 @@ Score Search::PVSearch(Thread &thread,
   // has improved in the past two or four plies. It also used as a metric for
   // adjusting pruning thresholds
   bool improving = false;
+  // Similar idea follows, but we check if the opponent's evaluation has been
+  // falling
+  bool opponent_worsening = false;
 
   StackEntry *past_stack = nullptr;
   if ((stack - 2)->static_eval != kScoreNone) {
@@ -575,8 +578,9 @@ Score Search::PVSearch(Thread &thread,
     past_stack = stack - 4;
   }
 
-  if (past_stack && !stack->in_check) {
-    improving = stack->static_eval > past_stack->static_eval;
+  if (!stack->in_check) {
+    improving = past_stack && stack->static_eval > past_stack->static_eval;
+    opponent_worsening = stack->static_eval + (stack - 1)->static_eval > 1;
   }
 
   (stack + 1)->ClearKillerMoves();
@@ -588,10 +592,10 @@ Score Search::PVSearch(Thread &thread,
     // fall below beta anytime soon
     if (depth <= kRevFutDepth && !stack->excluded_tt_move &&
         stack->eval >= beta) {
+      const int improving_margin =
+          (improving && !opponent_easy_capture) * 1.5 * kRevFutMargin;
       const int futility_margin =
-          depth * kRevFutMargin -
-          static_cast<int>((improving && !opponent_easy_capture) * 1.5 *
-                           kRevFutMargin) +
+          depth * kRevFutMargin - improving_margin - 20 * opponent_worsening -
           (stack - 1)->history_score / kRevFutHistoryDiv;
       if (stack->eval - std::max(futility_margin, 20) >= beta) {
         // Return (eval + beta) / 2 as a balanced score: higher than the beta


### PR DESCRIPTION
STC
```
Elo   | 2.09 +- 1.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 47614 W: 11754 L: 11467 D: 24393
Penta | [215, 5690, 11727, 5943, 232]
https://chess.aronpetkovski.com/test/6030/
```
LTC
```
Elo   | 3.16 +- 2.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23414 W: 5383 L: 5170 D: 12861
Penta | [15, 2617, 6235, 2820, 20]
https://chess.aronpetkovski.com/test/6045/
```