### PR TITLE
Allow LMR to increase depth in all-nodes

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -906,7 +906,7 @@ Score Search::PVSearch(Thread &thread,
           move == stack->killer_moves[0] || move == stack->killer_moves[1];
 
       // Ensure the reduction doesn't give us a depth below 0
-      reduction = std::clamp<int>(reduction, -in_pv_node, new_depth - 1);
+      reduction = std::clamp<int>(reduction, -(!in_pv_node && !cut_node), new_depth - 1);
 
       // Null window search at reduced depth to see if the move has potential
       score = -PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -906,7 +906,7 @@ Score Search::PVSearch(Thread &thread,
           move == stack->killer_moves[0] || move == stack->killer_moves[1];
 
       // Ensure the reduction doesn't give us a depth below 0
-      reduction = std::clamp<int>(reduction, 0, new_depth - 1);
+      reduction = std::clamp<int>(reduction, -in_pv_node, new_depth - 1);
 
       // Null window search at reduced depth to see if the move has potential
       score = -PVSearch<NodeType::kNonPV>(


### PR DESCRIPTION
```
Elo   | 4.35 +- 2.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17484 W: 4301 L: 4082 D: 9101
Penta | [55, 2018, 4388, 2215, 66]
https://chess.aronpetkovski.com/test/6106/
```