### PR TITLE
Fix positive SEE threshold being applied for quiet moves

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -801,7 +801,8 @@ Score Search::PVSearch(Thread &thread,
           stack->history_score / kSeePruneHistDiv;
       if (depth <= kSeePruneDepth &&
           move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
-          !eval::StaticExchange(move, see_threshold, state)) {
+          !eval::StaticExchange(
+              move, is_quiet ? std::min(see_threshold, 0) : 0, state)) {
         continue;
       }
 
@@ -906,7 +907,8 @@ Score Search::PVSearch(Thread &thread,
           move == stack->killer_moves[0] || move == stack->killer_moves[1];
 
       // Ensure the reduction doesn't give us a depth below 0
-      reduction = std::clamp<int>(reduction, -(!in_pv_node && !cut_node), new_depth - 1);
+      reduction = std::clamp<int>(
+          reduction, -(!in_pv_node && !cut_node), new_depth - 1);
 
       // Null window search at reduced depth to see if the move has potential
       score = -PVSearch<NodeType::kNonPV>(

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -802,7 +802,7 @@ Score Search::PVSearch(Thread &thread,
       if (depth <= kSeePruneDepth &&
           move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
           !eval::StaticExchange(
-              move, is_quiet ? std::min(see_threshold, 0) : 0, state)) {
+              move, is_quiet ? std::min(see_threshold, 0) : see_threshold, state)) {
         continue;
       }
 


### PR DESCRIPTION
```
Elo   | 0.57 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 28056 W: 6825 L: 6779 D: 14452
Penta | [114, 3181, 7373, 3265, 95]
https://chess.aronpetkovski.com/test/6147/
```