### PR TITLE
Tweak non-pawn correction history

### DIFF
--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -78,41 +78,46 @@ class CorrectionHistory {
                                         Score static_eval) const {
     const Score pawn_correction =
         (pawn_table_[state.turn][GetPawnTableIndex(state)] *
-         kPawnCorrectionWeight) / 256;
+         kPawnCorrectionWeight) /
+        256;
     const I32 non_pawn_white_correction =
         (non_pawn_table_[state.turn][Color::kWhite]
                         [GetNonPawnTableIndex(state, Color::kWhite)] *
-         kNonPawnCorrectionWeight) / 256;
+         kNonPawnCorrectionWeight) /
+        256;
     const I32 non_pawn_black_correction =
         (non_pawn_table_[state.turn][Color::kBlack]
                         [GetNonPawnTableIndex(state, Color::kBlack)] *
-         kNonPawnCorrectionWeight) / 256;
+         kNonPawnCorrectionWeight) /
+        256;
     const I32 minor_correction =
         (minor_table_[state.turn][GetMinorTableIndex(state)] *
-         kMinorCorrectionWeight) / 256;
+         kMinorCorrectionWeight) /
+        256;
     const I32 major_correction =
         (major_table_[state.turn][GetMajorTableIndex(state)] *
-         kMajorCorrectionWeight) / 256;
+         kMajorCorrectionWeight) /
+        256;
     const I32 continuation_correction = [&]() -> I32 {
       if (stack->ply >= 2 && (stack - 1)->move && (stack - 2)->move) {
         return (continuation_table_[state.turn][(stack - 2)->moved_piece]
                                    [(stack - 2)->move.GetTo()]
                                    [(stack - 1)->moved_piece]
                                    [(stack - 1)->move.GetTo()] *
-                kContinuationCorrectionWeight) / 256;
+                kContinuationCorrectionWeight) /
+               256;
       }
       return 0;
     }();
-    const I32 correction =
-        pawn_correction +
-        (non_pawn_white_correction + non_pawn_black_correction) / 2 +
-        (minor_correction + major_correction) / 2 + continuation_correction;
+    const I32 correction = pawn_correction + non_pawn_white_correction +
+                           non_pawn_black_correction +
+                           (minor_correction + major_correction) / 2 +
+                           continuation_correction;
     const I32 adjusted_score = static_cast<I32>(static_eval) + correction / 256;
     // Ensure no static evaluations are mate scores
     return std::clamp(
         adjusted_score, -kMateInMaxPlyScore + 1, kMateInMaxPlyScore - 1);
   }
-
 
  private:
   [[nodiscard]] int CalculateWeight(int depth) {


### PR DESCRIPTION
```
Elo   | 3.80 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 20546 W: 5087 L: 4862 D: 10597
Penta | [97, 2390, 5082, 2599, 105]
https://chess.aronpetkovski.com/test/6231/
```