### PR TITLE
Verify NMP cutoff scores at high-depths

### DIFF
--- a/src/engine/evaluation/nnue/accumulator.h
+++ b/src/engine/evaluation/nnue/accumulator.h
@@ -50,9 +50,9 @@ static std::array<I16, arch::kHiddenLayerSize>& GetFeatureTable(
 
   const int relative_king_square = king_square ^ (56 * perspective);
   const int king_bucket_idx = kKingBucketMap[relative_king_square];
-  const int square_idx = static_cast<int>(square ^ (56 * perspective));
-  const int color_idx = static_cast<int>(perspective != piece_color);
-  const int piece_idx = static_cast<int>(piece);
+  const int square_idx = square ^ 56 * perspective;
+  const int color_idx = perspective != piece_color;
+  const int piece_idx = piece;
 
   return network
       ->feature_weights[king_bucket_idx][color_idx][piece_idx][square_idx];
@@ -133,17 +133,25 @@ class PerspectiveAccumulator {
   }
 
 #if BUILD_HAS_SIMD
-  void AddFeatures4(
-      Color perspective,
-      Square king_square,
-      Square square1, Square square2, Square square3, Square square4,
-      PieceType piece,
-      Color color1, Color color2, Color color3, Color color4) {
-
-    const auto& table1 = GetFeatureTable(square1, king_square, piece, color1, perspective);
-    const auto& table2 = GetFeatureTable(square2, king_square, piece, color2, perspective);
-    const auto& table3 = GetFeatureTable(square3, king_square, piece, color3, perspective);
-    const auto& table4 = GetFeatureTable(square4, king_square, piece, color4, perspective);
+  void AddFeatures4(Color perspective,
+                    Square king_square,
+                    Square square1,
+                    Square square2,
+                    Square square3,
+                    Square square4,
+                    PieceType piece,
+                    Color color1,
+                    Color color2,
+                    Color color3,
+                    Color color4) {
+    const auto& table1 =
+        GetFeatureTable(square1, king_square, piece, color1, perspective);
+    const auto& table2 =
+        GetFeatureTable(square2, king_square, piece, color2, perspective);
+    const auto& table3 =
+        GetFeatureTable(square3, king_square, piece, color3, perspective);
+    const auto& table4 =
+        GetFeatureTable(square4, king_square, piece, color4, perspective);
 
     constexpr int simd_width = sizeof(simd::Vepi16) / sizeof(I16);
     for (int i = 0; i < arch::kHiddenLayerSize; i += simd_width) {
@@ -163,14 +171,13 @@ class PerspectiveAccumulator {
   }
 #endif
 
-  void AddFeature(
-      Color perspective,
-      Square king_square,
-      Square square,
-      PieceType piece,
-      Color piece_color) {
-
-    const auto& table = GetFeatureTable(square, king_square, piece, piece_color, perspective);
+  void AddFeature(Color perspective,
+                  Square king_square,
+                  Square square,
+                  PieceType piece,
+                  Color piece_color) {
+    const auto& table =
+        GetFeatureTable(square, king_square, piece, piece_color, perspective);
 
 #if BUILD_HAS_SIMD
     constexpr int simd_width = sizeof(simd::Vepi16) / sizeof(I16);
@@ -187,14 +194,13 @@ class PerspectiveAccumulator {
 #endif
   }
 
-  void SubFeature(
-      Color perspective,
-      Square king_square,
-      Square square,
-      PieceType piece,
-      Color piece_color) {
-
-    const auto& table = GetFeatureTable(square, king_square, piece, piece_color, perspective);
+  void SubFeature(Color perspective,
+                  Square king_square,
+                  Square square,
+                  PieceType piece,
+                  Color piece_color) {
+    const auto& table =
+        GetFeatureTable(square, king_square, piece, piece_color, perspective);
 
 #if BUILD_HAS_SIMD
     constexpr int simd_width = sizeof(simd::Vepi16) / sizeof(I16);
@@ -212,15 +218,19 @@ class PerspectiveAccumulator {
 #endif
   }
 
-  void AddSubFeatures(
-      const PerspectiveAccumulator& previous,
-      Color perspective,
-      Square king_square,
-      Square add_square, PieceType add_piece, Color add_piece_color,
-      Square sub_square, PieceType sub_piece, Color sub_piece_color) {
-
-    const auto& add_table = GetFeatureTable(add_square, king_square, add_piece, add_piece_color, perspective);
-    const auto& sub_table = GetFeatureTable(sub_square, king_square, sub_piece, sub_piece_color, perspective);
+  void AddSubFeatures(const PerspectiveAccumulator& previous,
+                      Color perspective,
+                      Square king_square,
+                      Square add_square,
+                      PieceType add_piece,
+                      Color add_piece_color,
+                      Square sub_square,
+                      PieceType sub_piece,
+                      Color sub_piece_color) {
+    const auto& add_table = GetFeatureTable(
+        add_square, king_square, add_piece, add_piece_color, perspective);
+    const auto& sub_table = GetFeatureTable(
+        sub_square, king_square, sub_piece, sub_piece_color, perspective);
 
 #if BUILD_HAS_SIMD
     constexpr int simd_width = sizeof(simd::Vepi16) / sizeof(I16);
@@ -240,17 +250,24 @@ class PerspectiveAccumulator {
 #endif
   }
 
-  void AddSubSubFeatures(
-      const PerspectiveAccumulator& previous,
-      Color perspective,
-      Square king_square,
-      Square add_square, PieceType add_piece, Color add_piece_color,
-      Square sub_square1, PieceType sub_piece1, Color sub_piece_color1,
-      Square sub_square2, PieceType sub_piece2, Color sub_piece_color2) {
-
-    const auto& add_table = GetFeatureTable(add_square, king_square, add_piece, add_piece_color, perspective);
-    const auto& sub_table1 = GetFeatureTable(sub_square1, king_square, sub_piece1, sub_piece_color1, perspective);
-    const auto& sub_table2 = GetFeatureTable(sub_square2, king_square, sub_piece2, sub_piece_color2, perspective);
+  void AddSubSubFeatures(const PerspectiveAccumulator& previous,
+                         Color perspective,
+                         Square king_square,
+                         Square add_square,
+                         PieceType add_piece,
+                         Color add_piece_color,
+                         Square sub_square1,
+                         PieceType sub_piece1,
+                         Color sub_piece_color1,
+                         Square sub_square2,
+                         PieceType sub_piece2,
+                         Color sub_piece_color2) {
+    const auto& add_table = GetFeatureTable(
+        add_square, king_square, add_piece, add_piece_color, perspective);
+    const auto& sub_table1 = GetFeatureTable(
+        sub_square1, king_square, sub_piece1, sub_piece_color1, perspective);
+    const auto& sub_table2 = GetFeatureTable(
+        sub_square2, king_square, sub_piece2, sub_piece_color2, perspective);
 
 #if BUILD_HAS_SIMD
     constexpr int simd_width = sizeof(simd::Vepi16) / sizeof(I16);
@@ -276,19 +293,29 @@ class PerspectiveAccumulator {
 #endif
   }
 
-  void AddAddSubSubFeatures(
-      const PerspectiveAccumulator& previous,
-      Color perspective,
-      Square king_square,
-      Square add_square1, PieceType add_piece1, Color add_piece_color1,
-      Square add_square2, PieceType add_piece2, Color add_piece_color2,
-      Square sub_square1, PieceType sub_piece1, Color sub_piece_color1,
-      Square sub_square2, PieceType sub_piece2, Color sub_piece_color2) {
-
-    const auto& add_table1 = GetFeatureTable(add_square1, king_square, add_piece1, add_piece_color1, perspective);
-    const auto& add_table2 = GetFeatureTable(add_square2, king_square, add_piece2, add_piece_color2, perspective);
-    const auto& sub_table1 = GetFeatureTable(sub_square1, king_square, sub_piece1, sub_piece_color1, perspective);
-    const auto& sub_table2 = GetFeatureTable(sub_square2, king_square, sub_piece2, sub_piece_color2, perspective);
+  void AddAddSubSubFeatures(const PerspectiveAccumulator& previous,
+                            Color perspective,
+                            Square king_square,
+                            Square add_square1,
+                            PieceType add_piece1,
+                            Color add_piece_color1,
+                            Square add_square2,
+                            PieceType add_piece2,
+                            Color add_piece_color2,
+                            Square sub_square1,
+                            PieceType sub_piece1,
+                            Color sub_piece_color1,
+                            Square sub_square2,
+                            PieceType sub_piece2,
+                            Color sub_piece_color2) {
+    const auto& add_table1 = GetFeatureTable(
+        add_square1, king_square, add_piece1, add_piece_color1, perspective);
+    const auto& add_table2 = GetFeatureTable(
+        add_square2, king_square, add_piece2, add_piece_color2, perspective);
+    const auto& sub_table1 = GetFeatureTable(
+        sub_square1, king_square, sub_piece1, sub_piece_color1, perspective);
+    const auto& sub_table2 = GetFeatureTable(
+        sub_square2, king_square, sub_piece2, sub_piece_color2, perspective);
 
 #if BUILD_HAS_SIMD
     constexpr int simd_width = sizeof(simd::Vepi16) / sizeof(I16);
@@ -311,8 +338,8 @@ class PerspectiveAccumulator {
     }
 #else
     for (int i = 0; i < arch::kHiddenLayerSize; ++i) {
-      values_[i] = previous[i] + add_table1[i] + add_table2[i] -
-                   sub_table1[i] - sub_table2[i];
+      values_[i] = previous[i] + add_table1[i] + add_table2[i] - sub_table1[i] -
+                   sub_table2[i];
     }
 #endif
   }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -69,10 +69,17 @@ void Search::IterativeDeepening(Thread &thread) {
   Move best_move = Move::NullMove();
   Score score = 0;
 
+  std::unique_ptr<uci::reporter::ReportInfo> report_info;
+  if (uci::reporter::using_uci) {
+    report_info = std::make_unique<uci::reporter::UCIReportInfo>();
+  } else {
+    report_info = std::make_unique<uci::reporter::PrettyReportInfo>();
+  }
+
   for (int depth = 1; depth <= time_mgmt_.GetSearchDepth(); depth++) {
     thread.sel_depth = 0, thread.root_depth = depth;
 
-    int window = static_cast<int>(kAspWindowDelta);
+    int window = kAspWindowDelta;
     Score alpha = -kInfiniteScore;
     Score beta = kInfiniteScore;
 
@@ -131,13 +138,6 @@ void Search::IterativeDeepening(Thread &thread) {
     if (thread.IsMainThread() &&
         time_mgmt_.ShouldStop(best_move, depth, thread)) {
       break;
-    }
-
-    std::unique_ptr<uci::reporter::ReportInfo> report_info;
-    if (uci::reporter::using_uci) {
-      report_info = std::make_unique<uci::reporter::UCIReportInfo>();
-    } else {
-      report_info = std::make_unique<uci::reporter::PrettyReportInfo>();
     }
 
     if (thread.IsMainThread() && !stop_.load(std::memory_order_relaxed) &&
@@ -621,7 +621,7 @@ Score Search::PVSearch(Thread &thread,
     // have the advantage
     if (!(stack - 1)->move.IsNull() && stack->eval >= beta &&
         stack->static_eval >= beta + kNmpBetaBase - kNmpBetaMult * depth &&
-        !stack->excluded_tt_move) {
+        !stack->excluded_tt_move && stack->ply >= thread.nmp_min_ply) {
       // Avoid null move pruning a position with high zugzwang potential
       const BitBoard non_pawn_king_pieces =
           state.KinglessOccupied(state.turn) & ~state.Pawns(state.turn);
@@ -650,7 +650,18 @@ Score Search::PVSearch(Thread &thread,
         // Prune if the result from our null window search around beta indicates
         // that the opponent still doesn't gain an advantage from the null move
         if (score >= beta) {
-          return score >= kTBWinInMaxPlyScore ? beta : score;
+          if (thread.nmp_min_ply != 0 || depth <= 14) {
+            return score >= kTBWinInMaxPlyScore ? beta : score;
+          }
+
+          thread.nmp_min_ply = stack->ply + 3 * (depth - reduction) / 4;
+          const Score verification_score = PVSearch<NodeType::kNonPV>(
+              thread, depth - reduction, beta - 1, beta, stack, false);
+          thread.nmp_min_ply = 0;
+
+          if (verification_score >= beta) {
+            return verification_score;
+          }
         }
       }
 
@@ -802,7 +813,9 @@ Score Search::PVSearch(Thread &thread,
       if (depth <= kSeePruneDepth &&
           move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
           !eval::StaticExchange(
-              move, is_quiet ? std::min(see_threshold, 0) : see_threshold, state)) {
+              move,
+              is_quiet ? std::min(see_threshold, 0) : see_threshold,
+              state)) {
         continue;
       }
 

--- a/src/engine/search/search.h
+++ b/src/engine/search/search.h
@@ -71,6 +71,7 @@ struct Thread {
   Score previous_score;
   U16 root_depth, sel_depth;
   U64 tb_hits;
+  U16 nmp_min_ply;
 };
 
 class Search {

--- a/src/engine/search/search.h
+++ b/src/engine/search/search.h
@@ -32,7 +32,8 @@ struct Thread {
         previous_score(kScoreNone),
         nodes_searched(0),
         sel_depth(0),
-        tb_hits(0) {
+        tb_hits(0),
+        nmp_min_ply(0) {
     NewGame();
   }
 
@@ -54,6 +55,8 @@ struct Thread {
   void Reset() {
     stack.Reset();
     scores.fill(kScoreNone);
+
+    nmp_min_ply = 0;
 
     // Reset info data
     nodes_searched = 0;

--- a/src/engine/search/time_mgmt.cc
+++ b/src/engine/search/time_mgmt.cc
@@ -56,7 +56,7 @@ bool DepthLimiter::ShouldStop(Move best_move, int depth, Thread& thread) {
   return depth >= max_depth_;
 }
 
-bool DepthLimiter::TimesUp(U32 nodes_searched) {
+bool DepthLimiter::TimesUp(U64 nodes_searched) {
   return false;
 }
 
@@ -79,7 +79,7 @@ bool NodeLimiter::ShouldStop(Move best_move, int depth, Thread& thread) {
   return soft_max_nodes_ != 0 && thread.nodes_searched >= soft_max_nodes_;
 }
 
-bool NodeLimiter::TimesUp(U32 nodes_searched) {
+bool NodeLimiter::TimesUp(U64 nodes_searched) {
   return max_nodes_ != 0 && nodes_searched >= max_nodes_;
 }
 
@@ -155,7 +155,7 @@ bool TimedLimiter::ShouldStop(Move best_move, int depth, Thread& thread) {
                               score_change_factor * node_count_factor;
 }
 
-bool TimedLimiter::TimesUp(U32 nodes_searched) {
+bool TimedLimiter::TimesUp(U64 nodes_searched) {
   return (nodes_searched & 4095) == 0 && TimeElapsed() >= hard_limit_;
 }
 
@@ -277,7 +277,7 @@ bool TimeManagement::ShouldStop(Move best_move, int depth, Thread& thread) {
   return false;
 }
 
-bool TimeManagement::TimesUp(U32 nodes_searched) {
+bool TimeManagement::TimesUp(U64 nodes_searched) {
   for (auto* limiter : active_limiters_) {
     if (limiter->TimesUp(nodes_searched)) {
       return true;

--- a/src/engine/search/time_mgmt.h
+++ b/src/engine/search/time_mgmt.h
@@ -36,7 +36,7 @@ class TimeLimiter {
 
   virtual bool ShouldStop(Move best_move, int depth, Thread &thread) = 0;
 
-  virtual bool TimesUp(U32 nodes_searched) = 0;
+  virtual bool TimesUp(U64 nodes_searched) = 0;
 
   virtual void Start() = 0;
 
@@ -53,7 +53,7 @@ class DepthLimiter : public TimeLimiter {
 
   bool ShouldStop(Move best_move, int depth, Thread &thread) override;
 
-  bool TimesUp(U32 nodes_searched) override;
+  bool TimesUp(U64 nodes_searched) override;
 
   void Start() override;
 
@@ -73,7 +73,7 @@ class NodeLimiter : public TimeLimiter {
 
   bool ShouldStop(Move best_move, int depth, Thread &thread) override;
 
-  bool TimesUp(U32 nodes_searched) override;
+  bool TimesUp(U64 nodes_searched) override;
 
   void Start() override;
 
@@ -94,7 +94,7 @@ class TimedLimiter : public TimeLimiter {
 
   bool ShouldStop(Move best_move, int depth, Thread &thread) override;
 
-  bool TimesUp(U32 nodes_searched) override;
+  bool TimesUp(U64 nodes_searched) override;
 
   void Start() override;
 
@@ -138,7 +138,7 @@ class TimeManagement {
 
   bool ShouldStop(Move best_move, int depth, Thread &thread);
 
-  bool TimesUp(U32 nodes_searched);
+  bool TimesUp(U64 nodes_searched);
 
   TimedLimiter* GetTimedLimiter();
 


### PR DESCRIPTION
Should mainly help with puzzle solving, although it may also be a gainer at higher depths.
```
Elo   | 0.38 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 32088 W: 7828 L: 7793 D: 16467
Penta | [115, 3748, 8295, 3759, 127]
https://chess.aronpetkovski.com/test/6242/
```