### PR TITLE
Add a static bias to history bonuses

### DIFF
--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -22,7 +22,7 @@ static I16 HistoryPenalty(I16 depth,
                           I16 scale = kHistPenaltyScale,
                           I16 max_bonus = kHistBonusMaxBonus) {
   return std::clamp<I16>(
-      -scale * depth - kHistBonusBiasbw, -max_bonus, max_bonus);
+      -scale * depth - kHistBonusBias, -max_bonus, max_bonus);
 }
 
 // Linear interpolation of the bonus and maximum score

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -7,10 +7,10 @@
 namespace search::history {
 
 TUNABLE(kHistBonusGravity, 10979, 8192, 32768, false);
-TUNABLE(kHistBonusScale, 147, 65, 260, false);
-TUNABLE(kHistPenaltyScale, 160, 65, 260, false);
+TUNABLE(kHistBonusScale, 137, 65, 260, false);
+TUNABLE(kHistPenaltyScale, 150, 65, 260, false);
 TUNABLE(kHistBonusMaxBonus, 1188, 580, 2318, true);
-TUNABLE(kHistBonusBias, 100, 580, 2318, true);
+TUNABLE(kHistBonusBias, 200, 580, 2318, true);
 
 static I16 HistoryBonus(I16 depth,
                         I16 scale = kHistBonusScale,
@@ -22,7 +22,7 @@ static I16 HistoryPenalty(I16 depth,
                           I16 scale = kHistPenaltyScale,
                           I16 max_bonus = kHistBonusMaxBonus) {
   return std::clamp<I16>(
-      -scale * depth - kHistBonusBias, -max_bonus, max_bonus);
+      -scale * depth - kHistBonusBiasbw, -max_bonus, max_bonus);
 }
 
 // Linear interpolation of the bonus and maximum score

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -7,20 +7,22 @@
 namespace search::history {
 
 TUNABLE(kHistBonusGravity, 10979, 8192, 32768, false);
-TUNABLE(kHistBonusScale, 137, 65, 260, false);
-TUNABLE(kHistPenaltyScale, 150, 65, 260, false);
+TUNABLE(kHistBonusScale, 147, 65, 260, false);
+TUNABLE(kHistPenaltyScale, 160, 65, 260, false);
 TUNABLE(kHistBonusMaxBonus, 1188, 580, 2318, true);
+TUNABLE(kHistBonusBias, 100, 580, 2318, true);
 
 static I16 HistoryBonus(I16 depth,
                         I16 scale = kHistBonusScale,
                         I16 max_bonus = kHistBonusMaxBonus) {
-  return std::clamp<I16>(scale * depth, -max_bonus, max_bonus);
+  return std::clamp<I16>(scale * depth - kHistBonusBias, -max_bonus, max_bonus);
 }
 
 static I16 HistoryPenalty(I16 depth,
                           I16 scale = kHistPenaltyScale,
                           I16 max_bonus = kHistBonusMaxBonus) {
-  return std::clamp<I16>(-scale * depth, -max_bonus, max_bonus);
+  return std::clamp<I16>(
+      -scale * depth - kHistBonusBias, -max_bonus, max_bonus);
 }
 
 // Linear interpolation of the bonus and maximum score

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -7,10 +7,10 @@
 namespace search::history {
 
 TUNABLE(kHistBonusGravity, 10979, 8192, 32768, false);
-TUNABLE(kHistBonusScale, 137, 65, 260, false);
-TUNABLE(kHistPenaltyScale, 150, 65, 260, false);
+TUNABLE(kHistBonusScale, 167, 65, 260, false);
+TUNABLE(kHistPenaltyScale, 180, 65, 260, false);
 TUNABLE(kHistBonusMaxBonus, 1188, 580, 2318, true);
-TUNABLE(kHistBonusBias, 200, 580, 2318, true);
+TUNABLE(kHistBonusBias, 100, 580, 2318, true);
 
 static I16 HistoryBonus(I16 depth,
                         I16 scale = kHistBonusScale,


### PR DESCRIPTION
```
Elo   | 5.24 +- 3.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 14116 W: 3539 L: 3326 D: 7251
Penta | [66, 1645, 3423, 1858, 66]
https://chess.aronpetkovski.com/test/6246/
```