### PR TITLE
Simplify away minor-piece correction history

### DIFF
--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -9,7 +9,6 @@ namespace search::history {
 
 TUNABLE(kPawnCorrectionWeight, 251, 0, 300, false);
 TUNABLE(kNonPawnCorrectionWeight, 248, 0, 300, false);
-TUNABLE(kMinorCorrectionWeight, 241, 0, 300, false);
 TUNABLE(kMajorCorrectionWeight, 261, 0, 300, false);
 TUNABLE(kContinuationCorrectionWeight, 249, 0, 300, false);
 
@@ -18,7 +17,6 @@ class CorrectionHistory {
   CorrectionHistory()
       : non_pawn_table_({}),
         pawn_table_({}),
-        minor_table_({}),
         major_table_({}),
         continuation_table_({}) {}
 
@@ -39,12 +37,6 @@ class CorrectionHistory {
     // Update pawn table score
     auto &pawn_table_score = pawn_table_[state.turn][GetPawnTableIndex(state)];
     pawn_table_score = UpdateTableScore(pawn_table_score, weight, scaled_bonus);
-
-    // Update minor piece table score
-    auto &minor_table_score =
-        minor_table_[state.turn][GetMinorTableIndex(state)];
-    minor_table_score =
-        UpdateTableScore(minor_table_score, weight, scaled_bonus);
 
     // Update major piece table score
     auto &major_table_score =
@@ -90,10 +82,6 @@ class CorrectionHistory {
                         [GetNonPawnTableIndex(state, Color::kBlack)] *
          kNonPawnCorrectionWeight) /
         256;
-    const I32 minor_correction =
-        (minor_table_[state.turn][GetMinorTableIndex(state)] *
-         kMinorCorrectionWeight) /
-        256;
     const I32 major_correction =
         (major_table_[state.turn][GetMajorTableIndex(state)] *
          kMajorCorrectionWeight) /
@@ -110,8 +98,7 @@ class CorrectionHistory {
       return 0;
     }();
     const I32 correction = pawn_correction + non_pawn_white_correction +
-                           non_pawn_black_correction +
-                           (minor_correction + major_correction) / 2 +
+                           non_pawn_black_correction + major_correction +
                            continuation_correction;
     const I32 adjusted_score = static_cast<I32>(static_eval) + correction / 256;
     // Ensure no static evaluations are mate scores
@@ -151,10 +138,6 @@ class CorrectionHistory {
     return state.pawn_key & 16383;
   }
 
-  [[nodiscard]] int GetMinorTableIndex(const BoardState &state) const {
-    return state.minor_key & 16383;
-  }
-
   [[nodiscard]] int GetMajorTableIndex(const BoardState &state) const {
     return state.major_key & 16383;
   }
@@ -166,7 +149,6 @@ class CorrectionHistory {
 
  private:
   MultiArray<Score, kNumColors, 16384> pawn_table_;
-  MultiArray<Score, kNumColors, 16384> minor_table_;
   MultiArray<Score, kNumColors, 16384> major_table_;
   MultiArray<Score, kNumColors, kNumColors, 16384> non_pawn_table_;
   MultiArray<Score, 2, kNumPieceTypes, 64, kNumPieceTypes, 64>


### PR DESCRIPTION
```
Elo   | 1.36 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 19098 W: 4710 L: 4635 D: 9753
Penta | [89, 2275, 4741, 2360, 84]
https://chess.aronpetkovski.com/test/6247/
```