### PR TITLE
Tweak capture history table structure

### DIFF
--- a/src/engine/search/history/capture_history.h
+++ b/src/engine/search/history/capture_history.h
@@ -13,8 +13,11 @@ class CaptureHistory {
 
   void UpdateScore(const BoardState &state, StackEntry *stack, I16 depth) {
     const I16 bonus = HistoryBonus(depth);
+    const auto from = stack->move.GetFrom(), to = stack->move.GetTo();
+    const auto captured =
+        stack->move.IsEnPassant(state) ? kPawn : state.GetPieceType(to);
     // Apply a linear dampening to the bonus as the depth increases
-    I16 &score = table_[state.turn][stack->move.GetFrom()][stack->move.GetTo()];
+    I16 &score = table_[state.turn][state.GetPieceType(from)][to][captured];
     score += ScaleBonus(score, bonus);
   }
 
@@ -23,19 +26,26 @@ class CaptureHistory {
     // Lower the score of the capture moves that failed to raise alpha
     for (I16 i = 0; i < captures.Size(); i++) {
       const Move bad_capture = captures[i];
+      const auto from = bad_capture.GetFrom(), to = bad_capture.GetTo();
+      const auto captured =
+          bad_capture.IsEnPassant(state) ? kPawn : state.GetPieceType(to);
       // Apply a linear dampening to the penalty as the depth increases
       I16 &bad_capture_score =
-          table_[state.turn][bad_capture.GetFrom()][bad_capture.GetTo()];
+          table_[state.turn][state.GetPieceType(from)][to][captured];
       bad_capture_score += ScaleBonus(bad_capture_score, penalty);
     }
   }
 
   [[nodiscard]] I16 GetScore(const BoardState &state, Move move) const {
-    return table_[state.turn][move.GetFrom()][move.GetTo()];
+    const auto from = move.GetFrom(), to = move.GetTo();
+    const auto captured =
+        move.IsEnPassant(state) ? kPawn : state.GetPieceType(to);
+    return table_[state.turn][state.GetPieceType(from)][to][captured];
   }
 
  private:
-  MultiArray<I16, kNumColors, kSquareCount, kSquareCount> table_;
+  MultiArray<I16, kNumColors, kNumPieceTypes, kSquareCount, kNumPieceTypes>
+      table_;
 };
 
 }  // namespace search::history


### PR DESCRIPTION
```
Elo   | 1.97 +- 1.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 52114 W: 12633 L: 12338 D: 27143
Penta | [196, 6216, 12955, 6477, 213]
https://chess.aronpetkovski.com/test/6340/
```