### PR TITLE
Only age TT entries when storing to them

### DIFF
--- a/src/engine/search/search.h
+++ b/src/engine/search/search.h
@@ -83,7 +83,6 @@ class RootMoveList {
   }
 
   inline RootMove &operator[](int i) {
-    assert(i >= 0 && i < count_);
     return list_[i];
   }
 

--- a/src/engine/search/time_mgmt.cc
+++ b/src/engine/search/time_mgmt.cc
@@ -76,7 +76,8 @@ int NodeLimiter::GetSearchDepth() const {
 }
 
 bool NodeLimiter::ShouldStop(Move best_move, int depth, Thread& thread) {
-  return soft_max_nodes_ != 0 && thread.nodes_searched >= soft_max_nodes_;
+  return soft_max_nodes_ != 0 && thread.nodes_searched >= soft_max_nodes_ ||
+         TimesUp(thread.nodes_searched);
 }
 
 bool NodeLimiter::TimesUp(U64 nodes_searched) {

--- a/src/engine/search/transpo.cc
+++ b/src/engine/search/transpo.cc
@@ -15,7 +15,6 @@ namespace search {
       const auto entry = &cluster.entries[i];
       // If this entry is available, we can attempt to write to it
       if (entry->key == 0 || entry->CompareKey(key)) {
-        entry->SetAge(age_);
         return entry;
       }
       // Always prefer the lowest quality entry


### PR DESCRIPTION
```
Elo   | 1.19 +- 0.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 143278 W: 35138 L: 34646 D: 73494
Penta | [546, 16616, 36856, 17042, 579]
https://chess.aronpetkovski.com/test/6382/
```