### PR TITLE
Switch to history gravity formula for correction history

### DIFF
--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -7,10 +7,10 @@
 
 namespace search::history {
 
-TUNABLE(kPawnCorrectionWeight, 100, 0, 300, false);
-TUNABLE(kNonPawnCorrectionWeight, 100, 0, 300, false);
-TUNABLE(kMajorCorrectionWeight, 100, 0, 300, false);
-TUNABLE(kContinuationCorrectionWeight, 100, 0, 300, false);
+TUNABLE(kPawnCorrectionWeight, 50, 0, 300, false);
+TUNABLE(kNonPawnCorrectionWeight, 50, 0, 300, false);
+TUNABLE(kMajorCorrectionWeight, 50, 0, 300, false);
+TUNABLE(kContinuationCorrectionWeight, 50, 0, 300, false);
 
 class CorrectionHistory {
  public:

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -7,10 +7,10 @@
 
 namespace search::history {
 
-TUNABLE(kPawnCorrectionWeight, 241, 0, 300, false);
-TUNABLE(kNonPawnCorrectionWeight, 234, 0, 300, false);
-TUNABLE(kMajorCorrectionWeight, 254, 0, 300, false);
-TUNABLE(kContinuationCorrectionWeight, 243, 0, 300, false);
+TUNABLE(kPawnCorrectionWeight, 60, 0, 300, false);
+TUNABLE(kNonPawnCorrectionWeight, 58, 0, 300, false);
+TUNABLE(kMajorCorrectionWeight, 64, 0, 300, false);
+TUNABLE(kContinuationCorrectionWeight, 60, 0, 300, false);
 
 class CorrectionHistory {
  public:
@@ -60,31 +60,26 @@ class CorrectionHistory {
                                         StackEntry *stack,
                                         Score static_eval) const {
     const Score pawn_correction =
-        (pawn_table_[state.turn][GetPawnTableIndex(state)] *
-         kPawnCorrectionWeight) /
-        256;
+        pawn_table_[state.turn][GetPawnTableIndex(state)] *
+        kPawnCorrectionWeight;
     const I32 non_pawn_white_correction =
-        (non_pawn_table_[state.turn][Color::kWhite]
-                        [GetNonPawnTableIndex(state, Color::kWhite)] *
-         kNonPawnCorrectionWeight) /
-        256;
+        non_pawn_table_[state.turn][Color::kWhite]
+                       [GetNonPawnTableIndex(state, Color::kWhite)] *
+        kNonPawnCorrectionWeight;
     const I32 non_pawn_black_correction =
-        (non_pawn_table_[state.turn][Color::kBlack]
-                        [GetNonPawnTableIndex(state, Color::kBlack)] *
-         kNonPawnCorrectionWeight) /
-        256;
+        non_pawn_table_[state.turn][Color::kBlack]
+                       [GetNonPawnTableIndex(state, Color::kBlack)] *
+        kNonPawnCorrectionWeight;
     const I32 major_correction =
-        (major_table_[state.turn][GetMajorTableIndex(state)] *
-         kMajorCorrectionWeight) /
-        256;
+        major_table_[state.turn][GetMajorTableIndex(state)] *
+        kMajorCorrectionWeight;
     const I32 continuation_correction = [&]() -> I32 {
       if (stack->ply >= 2 && (stack - 1)->move && (stack - 2)->move) {
-        return (continuation_table_[state.turn][(stack - 2)->moved_piece]
-                                   [(stack - 2)->move.GetTo()]
-                                   [(stack - 1)->moved_piece]
-                                   [(stack - 1)->move.GetTo()] *
-                kContinuationCorrectionWeight) /
-               256;
+        return continuation_table_[state.turn][(stack - 2)->moved_piece]
+                                  [(stack - 2)->move.GetTo()]
+                                  [(stack - 1)->moved_piece]
+                                  [(stack - 1)->move.GetTo()] *
+               kContinuationCorrectionWeight;
       }
       return 0;
     }();

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -7,10 +7,10 @@
 
 namespace search::history {
 
-TUNABLE(kPawnCorrectionWeight, 60, 0, 300, false);
-TUNABLE(kNonPawnCorrectionWeight, 58, 0, 300, false);
-TUNABLE(kMajorCorrectionWeight, 64, 0, 300, false);
-TUNABLE(kContinuationCorrectionWeight, 60, 0, 300, false);
+TUNABLE(kPawnCorrectionWeight, 100, 0, 300, false);
+TUNABLE(kNonPawnCorrectionWeight, 100, 0, 300, false);
+TUNABLE(kMajorCorrectionWeight, 100, 0, 300, false);
+TUNABLE(kContinuationCorrectionWeight, 100, 0, 300, false);
 
 class CorrectionHistory {
  public:

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -99,7 +99,7 @@ class CorrectionHistory {
     const I32 adjusted_score = static_cast<I32>(static_eval) + correction;
     // Ensure no static evaluations are mate scores
     return std::clamp(
-        adjusted_score, -kMateInMaxPlyScore + 1, kMateInMaxPlyScore - 1);
+        adjusted_score, -kTBWinInMaxPlyScore + 1, kTBWinInMaxPlyScore - 1);
   }
 
  private:


### PR DESCRIPTION
```
Elo   | 6.31 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11294 W: 2795 L: 2590 D: 5909
Penta | [30, 1317, 2765, 1488, 47]
https://chess.aronpetkovski.com/test/6549/
```