### PR TITLE
Update capture history in quiescent search

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -324,9 +324,6 @@ Score Search::QuiescentSearch(Thread &thread,
       continue;
     }
 
-    const bool is_quiet = !move.IsNoisy(state);
-    const bool is_capture = move.IsCapture(state);
-
     // QS Futility Pruning: Prune capture moves that don't win material if the
     // static eval is behind alpha by some margin
     if (!stack->in_check && move.IsCapture(state) && futility_score <= alpha &&
@@ -335,10 +332,14 @@ Score Search::QuiescentSearch(Thread &thread,
       continue;
     }
 
-    ++thread.nodes_searched;
-
     // Prefetch the TT entry for the next move as early as possible
     transposition_table_.Prefetch(board.PredictKeyAfter(move));
+
+    const bool is_quiet = !move.IsNoisy(state);
+    const bool is_capture = move.IsCapture(state);
+
+    stack->move = move;
+    ++thread.nodes_searched;
 
     board.MakeMove(move);
     const Score score =

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -339,6 +339,15 @@ Score Search::QuiescentSearch(Thread &thread,
     const bool is_capture = move.IsCapture(state);
 
     stack->move = move;
+    stack->moved_piece = state.GetPieceType(move.GetFrom());
+    stack->capture_move = move.IsCapture(state);
+    stack->continuation_entry =
+        history.continuation_history->GetEntry(state, move);
+    stack->history_score =
+        move.IsCapture(state)
+            ? history.GetCaptureMoveScore(state, move)
+            : history.GetQuietMoveScore(state, move, stack->threats, stack);
+
     ++thread.nodes_searched;
 
     board.MakeMove(move);


### PR DESCRIPTION
STC
```
Elo   | 1.44 +- 1.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 92788 W: 22492 L: 22107 D: 48189
Penta | [342, 11071, 23229, 11364, 388]
https://chess.aronpetkovski.com/test/6554/
```

Unfinished LTC
```
Elo   | 2.80 +- 4.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 0.67 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6586 W: 1554 L: 1501 D: 3531
Penta | [4, 771, 1697, 810, 11]
https://chess.aronpetkovski.com/test/6565/
```