### PR TITLE
More futility pruning in non-PV nodes

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -843,7 +843,7 @@ Score Search::PVSearch(Thread &thread,
     // Pruning guards
     if (!in_root && best_score > -kTBWinInMaxPlyScore) {
       int reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
-      reduction += !in_pv_node - tt_was_in_pv;
+      reduction += !in_pv_node;
       reduction -= stack->history_score /
                    static_cast<int>(is_quiet ? kLmrHistDiv : kLmrCaptHistDiv);
       reduction += !improving;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -843,6 +843,7 @@ Score Search::PVSearch(Thread &thread,
     // Pruning guards
     if (!in_root && best_score > -kTBWinInMaxPlyScore) {
       int reduction = tables::kLateMoveReduction[is_quiet][depth][moves_seen];
+      reduction += !in_pv_node - tt_was_in_pv;
       reduction -= stack->history_score /
                    static_cast<int>(is_quiet ? kLmrHistDiv : kLmrCaptHistDiv);
       reduction += !improving;


### PR DESCRIPTION
Test was actually playing at twice the TC listed due to reference NPS mismatch.
```
Elo   | 2.39 +- 2.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.80 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22434 W: 5390 L: 5236 D: 11808
Penta | [46, 2584, 5819, 2706, 62]
https://chess.aronpetkovski.com/test/6984/
```