### PR TITLE
Update last move's pawn history based on static eval difference

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -619,6 +619,8 @@ Score Search::PVSearch(Thread &thread,
                         kEvalHistUpdateMax);
     history.quiet_history->UpdateMoveScore(
         FlipColor(state.turn), prev_stack->move, prev_stack->threats, bonus);
+    history.pawn_history->UpdateMoveScore(
+        board.GetStateHistory().Back(), prev_stack->move, bonus);
   }
 
   stack->threats = state.threats;


### PR DESCRIPTION
```
Elo   | 2.39 +- 1.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 38138 W: 9308 L: 9046 D: 19784
Penta | [138, 4538, 9479, 4752, 162]
https://chess.aronpetkovski.com/test/7014/
```