### PR TITLE
Tweak negative extensions and singular extension minimum depth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(BUILD_SSE41_POPCNT "Build with SSE4.1 + POPCNT optimizations" OFF)
 option(BUILD_DEBUG "Build with debug information" OFF)
 
 # Allow user to specify EVALFILE through CMake
-set(NETWORK_NAME dialga-new)
+set(NETWORK_NAME dialga)
 set(EVALFILE "${EVALFILE}" CACHE STRING "Path to the evaluation (.nnue) file")
 set(NNUE_URL "https://github.com/aronpetko/integral-networks/releases/download/${NETWORK_NAME}/${NETWORK_NAME}.nnue")
 set(NNUE_PATH "${PROJECT_SOURCE_DIR}/${NETWORK_NAME}.nnue")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(BUILD_SSE41_POPCNT "Build with SSE4.1 + POPCNT optimizations" OFF)
 option(BUILD_DEBUG "Build with debug information" OFF)
 
 # Allow user to specify EVALFILE through CMake
-set(NETWORK_NAME dialga)
+set(NETWORK_NAME dialga-new)
 set(EVALFILE "${EVALFILE}" CACHE STRING "Path to the evaluation (.nnue) file")
 set(NNUE_URL "https://github.com/aronpetko/integral-networks/releases/download/${NETWORK_NAME}/${NETWORK_NAME}.nnue")
 set(NNUE_PATH "${PROJECT_SOURCE_DIR}/${NETWORK_NAME}.nnue")

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -63,7 +63,7 @@ TUNABLE(kLmrComplexityDiff, 81, 5, 150, false);
 TUNABLE(kDoDeeperBase, 35, 5, 70, false);
 TUNABLE(kDoShallowerBase, 5, 0, 30, false);
 
-TUNABLE(kSeDepth, 6, 6, 12, true);
+TUNABLE(kSeDepth, 5, 6, 12, true);
 TUNABLE(kSeDepthReduction, 7, 0, 30, false);
 TUNABLE(kSeDoubleMargin, 11, 0, 50, false);
 TUNABLE(kSeTripleMargin, 81, 20, 250, false);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -884,7 +884,7 @@ Score Search::PVSearch(Thread &thread,
         continue;
       }
 
-      // History Pruning: Prune quiet moves with a low history score moves at
+      // History Pruning: Prune moves with a low history score moves at
       // near-leaf nodes
       const int history_margin =
           is_quiet ? kHistThreshBase + kHistThreshMult * depth
@@ -895,11 +895,10 @@ Score Search::PVSearch(Thread &thread,
       }
     }
 
-    int extensions = 0;
-
     // Singular Extensions: If a TT move exists and its score is accurate enough
     // (close enough in depth), we perform a reduced-depth search with the TT
     // move excluded to see if any other moves can beat it.
+    int extensions = 0;
     if (!in_root && depth >= kSeDepth && move == tt_move &&
         stack->ply < thread.root_depth * 2) {
       const bool is_accurate_tt_score =
@@ -945,7 +944,7 @@ Score Search::PVSearch(Thread &thread,
         else if (tt_entry->score >= beta) {
           extensions = -2 + in_pv_node;
         } else if (cut_node) {
-          extensions = -1;
+          extensions = -2;
         }
       }
     }


### PR DESCRIPTION
Speculative LTC passed, STC looked neutral.
```
Elo   | 2.88 +- 2.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27058 W: 6411 L: 6187 D: 14460
Penta | [17, 3094, 7096, 3292, 30]
https://chess.aronpetkovski.com/test/7097/
```