### PR TITLE
Bonus to Prior Countermoves on Fail Low

### DIFF
--- a/src/chess/move.cc
+++ b/src/chess/move.cc
@@ -1,3 +1,5 @@
+#include "move.h"
+
 #include "board.h"
 
 Move Move::NullMove() {

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -7,6 +7,7 @@
 #include "../uci/reporter.h"
 #include "constants.h"
 #include "fmt/format.h"
+#include "history/bonus.h"
 #include "move_picker.h"
 #include "syzygy/syzygy.h"
 #include "time_mgmt.h"
@@ -1110,6 +1111,13 @@ Score Search::PVSearch(Thread &thread,
     // Since "good" captures are expected to be the best moves, we apply a
     // penalty to all captures even in the case where the best move was quiet
     history.capture_history->Penalize(state, depth, captures);
+  } else if (!prev_stack->capture_move &&
+             !(prev_stack->move.GetType() == MoveType::kPromotion) &&
+             !prev_stack->move.IsNull()) {
+    history.quiet_history->UpdateMoveScore(FlipColor(state.turn),
+                                           prev_stack->move,
+                                           prev_stack->threats,
+                                           history::HistoryBonus(depth));
   }
 
   if (syzygy::enabled) {


### PR DESCRIPTION
Passed STC:
```Elo   | 1.93 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 53894 W: 13237 L: 12937 D: 27720
Penta | [239, 6405, 13373, 6677, 253]
```
https://chess.aronpetkovski.com/test/7087/

Passed LTC:
```
Elo   | 2.00 +- 2.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.06 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16368 W: 3841 L: 3747 D: 8780
Penta | [11, 1852, 4355, 1964, 2]
```
https://chess.aronpetkovski.com/test/7111/