### PR TITLE
Fix pawn history population

### DIFF
--- a/src/engine/search/history/pawn_history.h
+++ b/src/engine/search/history/pawn_history.h
@@ -10,7 +10,15 @@ namespace search::history {
 class PawnHistory {
  public:
   PawnHistory() : table_({}) {
-    std::memset(table_.data(), -1000, sizeof(table_));
+    for (auto &one : table_) {
+      for (auto &two : one) {
+        for (auto &three : two) {
+          for (auto &four : three) {
+            four = -1000;
+          }
+        }
+      }
+    }
   }
 
   void UpdateMoveScore(const BoardState &state, Move move, I16 bonus) {


### PR DESCRIPTION
```
Elo   | 3.64 +- 3.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 9916 W: 2413 L: 2309 D: 5194
Penta | [33, 1143, 2511, 1229, 42]
https://chess.aronpetkovski.com/test/7222/
```