### PR TITLE
Tweak aspiration window with squared average score of the best move

### DIFF
--- a/src/engine/search/search.h
+++ b/src/engine/search/search.h
@@ -28,9 +28,11 @@ enum class SearchType {
 struct RootMove {
   Move move;
   Score score;
+  Score average_score;
   PVLine pv;
 
-  RootMove(Move move, Score score) : move(move), score(score), pv({}) {}
+  RootMove(Move move, Score score)
+      : move(move), score(score), average_score(kScoreNone), pv({}) {}
   RootMove() = default;
 };
 


### PR DESCRIPTION
STC:
```
Elo   | 4.80 +- 2.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 15270 W: 3741 L: 3530 D: 7999
Penta | [66, 1729, 3844, 1920, 76]
```
https://chess.aronpetkovski.com/test/7338/

LTC:
```
Elo   | 3.09 +- 3.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.31 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11004 W: 2607 L: 2509 D: 5888
Penta | [7, 1256, 2881, 1348, 10]
```
https://chess.aronpetkovski.com/test/7344/

bench 2276556