### PR TITLE
Remove depth limit from SEE pruning

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -915,10 +915,9 @@ Score Search::PVSearch(Thread &thread,
       // Static Exchange Evaluation (SEE) Pruning: Skip moves that lose too
       // much material
       const int see_threshold =
-          (is_quiet ? kSeeQuietThresh * depth : kSeeNoisyThresh * depth) -
+          (is_quiet ? kSeeQuietThresh : kSeeNoisyThresh) * depth -
           stack->history_score / kSeePruneHistDiv;
-      if (depth <= kSeePruneDepth &&
-          move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
+      if (move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
           !eval::StaticExchange(
               move,
               is_quiet ? std::min(see_threshold, 0) : see_threshold,


### PR DESCRIPTION
```
Elo   | -0.50 +- 2.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -1.22 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19956 W: 4728 L: 4757 D: 10471
Penta | [86, 2392, 5039, 2387, 74]
```
<https://chess.aronpetkovski.com/test/7501/>

This would pass simplification, and probably scales at LTC.