### PR TITLE
Simplify `in_pv_node` condition in negative extensions

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -988,7 +988,7 @@ Score Search::PVSearch(Thread &thread,
         // Negative Extensions: Search less since the TT move was not
         // singular, and it might cause a beta cutoff again.
         else if (tt_entry->score >= beta) {
-          extensions = -2 + in_pv_node;
+          extensions = -2;
         } else if (cut_node) {
           extensions = -2;
         }


### PR DESCRIPTION
Would have passed simplification bounds a long time ago
```
Elo   | 0.73 +- 1.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.28 (-2.25, 2.89) [0.00, 3.00]
Games | N: 112106 W: 27088 L: 26852 D: 58166
Penta | [523, 13110, 28562, 13324, 534]
```
<https://chess.aronpetkovski.com/test/7602/>