### PR TITLE
Prevent noisy moves from being played as killer moves

### DIFF
--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -95,6 +95,7 @@ Move MovePicker::Next() {
     if (stack_) {
       const auto first_killer = stack_->killer_moves[0];
       if (first_killer && first_killer != tt_move_ &&
+          !first_killer.IsNoisy(state) &&
           board_.IsMovePseudoLegal(first_killer)) {
         return first_killer;
       }
@@ -107,6 +108,7 @@ Move MovePicker::Next() {
     if (stack_) {
       const auto second_killer = stack_->killer_moves[1];
       if (second_killer && second_killer != tt_move_ &&
+          !second_killer.IsNoisy(state) &&
           board_.IsMovePseudoLegal(second_killer)) {
         return second_killer;
       }
@@ -167,10 +169,14 @@ Move &MovePicker::SelectionSort(List<ScoredMove, kMaxMoves> &move_list,
 template <MoveGenType move_type>
 void MovePicker::GenerateAndScoreMoves(List<ScoredMove, kMaxMoves> &list) {
   const auto &killers = stack_->killer_moves;
+  const auto &state = board_.GetState();
+
   auto moves = move_gen::GenerateMoves<move_type>(board_);
   for (int i = 0; i < moves.Size(); i++) {
     auto move = moves[i];
-    if (move != tt_move_ && killers[0] != move && killers[1] != move) {
+    if (move != tt_move_ &&
+        (killers[0] != move || killers[0].IsNoisy(state)) &&
+        (killers[1] != move || killers[1].IsNoisy(state))) {
       list.Push({move, ScoreMove(move)});
     }
   }


### PR DESCRIPTION
```
Elo   | 3.59 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22156 W: 5421 L: 5192 D: 11543
Penta | [91, 2587, 5519, 2764, 117]
```
<https://chess.aronpetkovski.com/test/8327/>