### PR TITLE
Always replace TT entries from past searches

### DIFF
--- a/src/engine/search/transpo.cc
+++ b/src/engine/search/transpo.cc
@@ -42,7 +42,7 @@ void TranspositionTable::Save(TranspositionTableEntry *old_entry,
   if (!old_entry->CompareKey(key) ||
       new_entry.flag == TranspositionTableEntry::kExact ||
       new_entry.depth + 3 + 2 * in_pv >= old_entry->depth ||
-      new_entry.age != age_) {
+      old_entry->age != age_) {
     new_entry.age = age_;
 
     old_entry->key = static_cast<U16>(key);

--- a/src/engine/search/transpo.cc
+++ b/src/engine/search/transpo.cc
@@ -41,7 +41,8 @@ void TranspositionTable::Save(TranspositionTableEntry *old_entry,
 
   if (!old_entry->CompareKey(key) ||
       new_entry.flag == TranspositionTableEntry::kExact ||
-      new_entry.depth + 3 + 2 * in_pv >= old_entry->depth) {
+      new_entry.depth + 3 + 2 * in_pv >= old_entry->depth ||
+      new_entry.age != age_) {
     new_entry.age = age_;
 
     old_entry->key = static_cast<U16>(key);


### PR DESCRIPTION
```
Elo   | 1.84 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 58042 W: 14061 L: 13754 D: 30227
Penta | [231, 6779, 14739, 6996, 276]
```
<https://chess.aronpetkovski.com/test/8380/>
```
Elo   | 7.08 +- 3.50 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8830 W: 2122 L: 1942 D: 4766
Penta | [8, 904, 2414, 1078, 11]
```
<https://chess.aronpetkovski.com/test/8383/>