### PR TITLE
Return interpolated score during QS beta cutoff

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -14,6 +14,7 @@ TUNABLE(kAspWindowDepth, 4, 2, 8, true);
 TUNABLE(kAspWindowDelta, 7, 1, 50, false);
 TUNABLE_STEP(kAspWindowGrowth, 1.3944681232281486, 0.1, 2.0, false, 0.08);
 
+TUNABLE_STEP(kQsCutoffLerpFactor, 0.5, 0.0, 1.0, false, 0.05);
 TUNABLE_STEP(kQsFutMargin, 134, 20, 300, false, 20);
 
 TUNABLE(kEvalHistUpdateMult, 61, 20, 100, false);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -325,7 +325,8 @@ Score Search::QuiescentSearch(Thread &thread,
             tt_entry, new_tt_entry, zobrist_key, stack->ply, in_pv_node);
       }
 
-      return static_cast<Score>(std::lerp(best_score, beta, kQsCutoffLerpFactor));
+      return static_cast<Score>(
+          std::lerp(best_score, beta, kQsCutoffLerpFactor));
     }
 
     // Alpha can be updated if no cutoff occurred

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -325,7 +325,7 @@ Score Search::QuiescentSearch(Thread &thread,
             tt_entry, new_tt_entry, zobrist_key, stack->ply, in_pv_node);
       }
 
-      return best_score;
+      return static_cast<Score>(std::lerp(best_score, beta, kRevFutLerpFactor));
     }
 
     // Alpha can be updated if no cutoff occurred
@@ -991,7 +991,7 @@ Score Search::PVSearch(Thread &thread,
         // Multi-cut: The singular search had a beta cutoff, indicating that
         // the TT move was not singular. Therefore, we prune if the same score
         // would cause a cutoff based on our current search window
-        else if (tt_move_excluded_score >= beta  &&
+        else if (tt_move_excluded_score >= beta &&
                  std::abs(tt_move_excluded_score) < kTBWinInMaxPlyScore) {
           return tt_move_excluded_score;
         }

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -325,7 +325,7 @@ Score Search::QuiescentSearch(Thread &thread,
             tt_entry, new_tt_entry, zobrist_key, stack->ply, in_pv_node);
       }
 
-      return static_cast<Score>(std::lerp(best_score, beta, kRevFutLerpFactor));
+      return static_cast<Score>(std::lerp(best_score, beta, kQsCutoffLerpFactor));
     }
 
     // Alpha can be updated if no cutoff occurred


### PR DESCRIPTION
```
Elo   | 1.22 +- 0.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 130318 W: 31374 L: 30916 D: 68028
Penta | [522, 15613, 32513, 15907, 604]
```
<https://chess.aronpetkovski.com/test/8411/>