### PR TITLE
Increase assumed fail high negative extension amount

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -203,8 +203,9 @@ void Searcher::IterativeDeepening(Thread &thread) {
     transposition_table_.Age();
 
     if (print_info) {
-      fmt::println("bestmove {}",
-                   !thread.root_moves.Empty() ? best_move.move.ToString() : "0000");
+      fmt::println(
+          "bestmove {}",
+          !thread.root_moves.Empty() ? best_move.move.ToString() : "0000");
     }
   } else {
     SendStoppedSignal();
@@ -986,7 +987,9 @@ Score Searcher::PVSearch(Thread &thread,
       }
       // Negative Extensions: Search less since the TT move was not
       // singular, and it might cause a beta cutoff again.
-      else if (tt_entry->score >= beta || cut_node) {
+      else if (tt_entry->score >= beta) {
+        extensions = -3;
+      } else if (cut_node) {
         extensions = -2;
       }
     }


### PR DESCRIPTION
```
Elo   | 1.42 +- 1.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 99794 W: 24938 L: 24531 D: 50325
Penta | [568, 11801, 24731, 12250, 547]
```
<https://chess.aronpetkovski.com/test/8863/>