### PR TITLE
Restrict pinned pieces in SEE

### DIFF
--- a/src/chess/board.cc
+++ b/src/chess/board.cc
@@ -185,7 +185,7 @@ bool Board::IsMoveLegal(Move move) const {
 
   // If the piece being moved is pinned, verify that it's moving on the same
   // diagonal
-  if (state_.pinned.IsSet(from) &&
+  if (state_.pinned[us].IsSet(from) &&
       !(move_gen::RayIntersecting(from, to) & king_mask)) {
     return false;
   }
@@ -541,7 +541,7 @@ void Board::CalculateKingThreats() {
   state_.checkers &= their_pieces;
 
   // Calculate our potentially pinned pieces
-  state_.pinned = 0;
+  state_.pinned[us] = 0;
 
   // Calculate all the opponent's pieces that could reach our king
   BitBoard x_raying_pieces =
@@ -558,7 +558,7 @@ void Board::CalculateKingThreats() {
     } else if (num_blockers == 1) {
       // A piece is pinned if it's the only piece within a xray of an opponents
       // piece to our king
-      state_.pinned |= pinned;
+      state_.pinned[us] |= pinned;
     }
   }
 }

--- a/src/chess/board.h
+++ b/src/chess/board.h
@@ -95,7 +95,7 @@ struct BoardState {
         major_key(0ULL),
         non_pawn_keys({}),
         checkers(0ULL),
-        pinned(0ULL),
+        pinned({}),
         half_moves(0) {
     piece_on_square.fill(PieceType::kNone);
   }
@@ -273,7 +273,7 @@ struct BoardState {
   BitBoard checkers;
   BitBoard threats;
   std::array<BitBoard, kNumPieceTypes> threatened_by;
-  BitBoard pinned;
+  std::array<BitBoard, kNumColors> pinned;
 };
 
 class Board {

--- a/src/chess/move_gen.cc
+++ b/src/chess/move_gen.cc
@@ -473,7 +473,7 @@ MoveList GenerateMoves(const Board &board) {
   AddPawnMoves<move_type>(board, move_list);
 
   // Other piece moves
-  for (Square from : state.Knights(state.turn) & ~state.pinned) {
+  for (Square from : state.Knights(state.turn) & ~state.pinned[state.turn]) {
     for (Square to : KnightMoves(from) & targets) {
       move_list.Push(Move(from, to));
     }


### PR DESCRIPTION
Idea from Pawnocchio

STC
```
Elo   | 2.17 +- 1.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 49730 W: 12367 L: 12056 D: 25307
Penta | [256, 5873, 12358, 6060, 318]
```
<https://chess.aronpetkovski.com/test/9001/>

LTC
```
Elo   | 2.07 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.37 (-2.25, 2.89) [0.00, 2.50]
Games | N: 22300 W: 5326 L: 5193 D: 11781
Penta | [21, 2531, 5922, 2646, 30]
```
<https://chess.aronpetkovski.com/test/9007/>