### PR TITLE
Use corrected evaluation as a SEE threshold modifier in ProbCut

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -767,7 +767,7 @@ Score Searcher::PVSearch(Thread &thread,
       if (depth >= kProbcutDepth && std::abs(beta) < kTBWinInMaxPlyScore &&
           (!tt_hit || tt_entry->depth + 3 < depth ||
            tt_entry->score >= pc_beta)) {
-        const int pc_see = pc_beta - raw_static_eval;
+        const int pc_see = pc_beta - stack->eval;
         const Move pc_tt_move = eval::StaticExchange(tt_move, pc_see, state)
                                   ? tt_move
                                   : Move::NullMove();


### PR DESCRIPTION
Honestly cannot see how this isn't elo-gaining, so the test wasn't completed.
```
Elo   | 1.04 +- 1.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.78 (-2.25, 2.89) [0.00, 2.50]
Games | N: 125022 W: 30834 L: 30461 D: 63727
Penta | [645, 15053, 30781, 15348, 684]
```
<https://chess.aronpetkovski.com/test/9081/>