### PR TITLE
Fix LMR depth history adjustment granularity

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -885,7 +885,7 @@ Score Searcher::PVSearch(Thread &thread,
 
       // Reduce based on the history score of this move
       if (is_quiet) {
-        reduction -= stack->history_score / kLmrHistDiv * kLmrDepthHistQuiet;
+        reduction -= stack->history_score * kLmrDepthHistQuiet / kLmrHistDiv;
       }
 
       // Reduce more if our static evaluation is going down


### PR DESCRIPTION
```
Elo   | 2.72 +- 3.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 14568 W: 3717 L: 3603 D: 7248
Penta | [81, 1730, 3568, 1804, 101]
```
https://furybench.com/test/119/