### PR TITLE
Simplify pawn history usage

### DIFF
--- a/src/engine/search/history/history.h
+++ b/src/engine/search/history/history.h
@@ -43,7 +43,7 @@ class History {
            continuation_history->GetScore(state, move, stack - 1) +
            continuation_history->GetScore(state, move, stack - 2) +
            continuation_history->GetScore(state, move, stack - 4) +
-           pawn_history->GetScore(state, move) / 2;
+           pawn_history->GetScore(state, move);
   }
 
   [[nodiscard]] I32 GetCaptureMoveScore(const BoardState &state,


### PR DESCRIPTION
Would have passed simplification.
```
Elo   | 0.64 +- 1.39 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.01 (-2.25, 2.89) [0.00, 2.50]
Games | N: 63464 W: 15326 L: 15209 D: 32929
Penta | [200, 7585, 16049, 7694, 204]
```
https://furybench.com/test/191/