### PR TITLE
Use static evaluation correction difference in RFP

### DIFF
--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -56,7 +56,7 @@ struct StackEntry {
   // Number of ply from root
   I32 ply;
   // Scores at this ply
-  Score static_eval, eval, score;
+  Score static_eval, eval, score, eval_complexity;
   I64 history_score;
   // Best moves following down this ply
   PVLine pv;
@@ -92,6 +92,7 @@ struct StackEntry {
       : ply(ply),
         static_eval(kScoreNone),
         eval(kScoreNone),
+        eval_complexity(0),
         history_score(0),
         move(Move::NullMove()),
         excluded_tt_move(Move::NullMove()),


### PR DESCRIPTION
STC
```
Elo   | 2.38 +- 1.73 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 41686 W: 10217 L: 9931 D: 21538
Penta | [121, 4928, 10501, 5130, 163]
```
https://furybench.com/test/366/

```
Elo   | 4.87 +- 4.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 0.93 (-2.25, 2.89) [0.00, 2.50]
Games | N: 5284 W: 1272 L: 1198 D: 2814
Penta | [8, 591, 1369, 667, 7]
```
https://furybench.com/test/369/