### PR TITLE
Interpolate fail-high scores in QS

### DIFF
--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -15,6 +15,7 @@ TUNABLE_STEP(kAspWindowDelta, 8, 1, 50, false, 1);
 TUNABLE_STEP(kAspWindowGrowth, 1.3968181632525003, 0.1, 2.0, false, 0.03);
 
 TUNABLE_STEP(kQsCutoffLerpFactor, 0.46762757125234183, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFailHighLerpFactor, 0.5, 0.0, 1.0, false, 0.1);
 TUNABLE_STEP(kQsFutMargin, 156, 20, 300, false, 20);
 
 TUNABLE(kEvalHistUpdateMult, 63, 20, 100, false);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -432,7 +432,7 @@ Score Searcher::QuiescentSearch(Thread &thread,
   }
 
   // Return an interpolated score toward beta for a safety "cushion"
-  if (best_score >= beta && std::abs(beta) < kTBWinInMaxPlyScore) {
+  if (best_score >= beta && std::abs(best_score) < kTBWinInMaxPlyScore) {
     best_score = std::lerp(best_score, beta, 0.5);
   }
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -433,7 +433,8 @@ Score Searcher::QuiescentSearch(Thread &thread,
 
   // Return an interpolated score toward beta for a safety "cushion"
   if (best_score >= beta && std::abs(best_score) < kTBWinInMaxPlyScore) {
-    best_score = std::lerp(best_score, beta, 0.5);
+    best_score = static_cast<Score>(
+        std::lerp(best_score, beta, kQsFailHighLerpFactor));
   }
 
   TranspositionTableEntry::Flag tt_flag;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -431,6 +431,11 @@ Score Searcher::QuiescentSearch(Thread &thread,
     history.capture_history->Penalize(state, 1, captures);
   }
 
+  // Return an interpolated score toward beta for a safety "cushion"
+  if (best_score >= beta && std::abs(beta) < kTBWinInMaxPlyScore) {
+    best_score = std::lerp(best_score, beta, 0.5);
+  }
+
   TranspositionTableEntry::Flag tt_flag;
   if (alpha >= beta) {
     // Beta cutoff


### PR DESCRIPTION
STC
```
Elo   | 2.60 +- 1.83 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.50]
Games | N: 37530 W: 9258 L: 8977 D: 19295
Penta | [125, 4415, 9433, 4638, 154]
```
https://furybench.com/test/494/

LTC
```
Elo   | 1.17 +- 1.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.80 (-2.25, 2.89) [0.00, 2.50]
Games | N: 76704 W: 18216 L: 17958 D: 40530
Penta | [77, 8763, 20419, 9011, 82]
```
https://furybench.com/test/518/