### PR TITLE
LMP more often when static eval suggests a fail high

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -912,7 +912,8 @@ Score Searcher::PVSearch(Thread &thread,
 
       // Late Move Pruning: Skip (late) quiet moves if we've already searched
       // the most promising moves
-      const int lmp_threshold = (kLmpBase + depth * depth) / (3 - improving);
+      const int lmp_threshold =
+          (kLmpBase + depth * depth) / (3 - (improving || stack->eval >= beta));
       if (is_quiet && moves_seen >= lmp_threshold) {
         move_picker.SkipQuiets();
         continue;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -716,7 +716,7 @@ Score Searcher::PVSearch(Thread &thread,
     // Razoring: At low depths, if this node seems like it might fail low, we
     // do a quiescent search to determine if we should prune
     if (!stack->excluded_tt_move && depth <= kRazoringDepth && alpha < 2000 &&
-        stack->static_eval + kRazoringMult * (depth - !improving) < alpha) {
+        stack->static_eval + 300 + 200 * depth * depth <= alpha) {
       const Score razoring_score =
           QuiescentSearch<NodeType::kNonPV>(thread, alpha, alpha + 1, stack);
       if (razoring_score <= alpha) {

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -715,7 +715,7 @@ Score Searcher::PVSearch(Thread &thread,
 
     // Razoring: At low depths, if this node seems like it might fail low, we
     // do a quiescent search to determine if we should prune
-    if (!stack->excluded_tt_move && depth <= kRazoringDepth && alpha < 2000 &&
+    if (!stack->excluded_tt_move && alpha < 2000 &&
         stack->static_eval + 300 + 200 * depth * depth <= alpha) {
       const Score razoring_score =
           QuiescentSearch<NodeType::kNonPV>(thread, alpha, alpha + 1, stack);

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -715,8 +715,8 @@ Score Searcher::PVSearch(Thread &thread,
 
     // Razoring: At low depths, if this node seems like it might fail low, we
     // do a quiescent search to determine if we should prune
-    if (!stack->excluded_tt_move && alpha < 2000 &&
-        stack->static_eval + 300 + 200 * depth * depth <= alpha) {
+    if (!stack->excluded_tt_move && depth <= kRazoringDepth && alpha < 2000 &&
+        stack->static_eval + kRazoringMult * (depth - !improving) < alpha) {
       const Score razoring_score =
           QuiescentSearch<NodeType::kNonPV>(thread, alpha, alpha + 1, stack);
       if (razoring_score <= alpha) {


### PR DESCRIPTION
STC
```
Elo   | 3.13 +- 2.06 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 29168 W: 7117 L: 6854 D: 15197
Penta | [93, 3394, 7355, 3641, 101]
```
https://furybench.com/test/1025/


LTC
```
Elo   | 2.07 +- 2.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 1.37 (-2.25, 2.89) [0.00, 2.50]
Games | N: 22460 W: 5319 L: 5185 D: 11956
Penta | [21, 2595, 5864, 2729, 21]
```
https://furybench.com/test/1032/