### PR TITLE
Add recapture guard to QS futility pruning

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -364,8 +364,9 @@ Score Searcher::QuiescentSearch(Thread &thread,
 
     // QS Futility Pruning: Prune noisy moves that don't win material if the
     // static eval is behind alpha by some margin
-    if (!stack->in_check && move.GetTo() != (stack - 1)->move.GetTo() &&
-        move.IsNoisy(state) && futility_score <= alpha &&
+    if (!stack->in_check &&
+        (!(stack - 1)->move || move.GetTo() != (stack - 1)->move.GetTo()) &&
+        move.IsCapture(state) && futility_score <= alpha &&
         !eval::StaticExchange(move, 1, state)) {
       best_score = std::max(best_score, futility_score);
       continue;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -93,7 +93,8 @@ void Searcher::IterativeDeepening(Thread &thread) {
       int window =
           kAspWindowDelta + average_score * average_score / kAspWindowScoreDiv;
 
-      Score alpha = std::max<int>(-kInfiniteScore, cur_best_move.score - window);
+      Score alpha =
+          std::max<int>(-kInfiniteScore, cur_best_move.score - window);
       Score beta = std::min<int>(kInfiniteScore, cur_best_move.score + window);
 
       int fail_high_count = 0;
@@ -361,9 +362,10 @@ Score Searcher::QuiescentSearch(Thread &thread,
       continue;
     }
 
-    // QS Futility Pruning: Prune capture moves that don't win material if the
+    // QS Futility Pruning: Prune noisy moves that don't win material if the
     // static eval is behind alpha by some margin
-    if (!stack->in_check && move.IsCapture(state) && futility_score <= alpha &&
+    if (!stack->in_check && move.GetTo() != (stack - 1)->move.GetTo() &&
+        move.IsNoisy(state) && futility_score <= alpha &&
         !eval::StaticExchange(move, 1, state)) {
       best_score = std::max(best_score, futility_score);
       continue;


### PR DESCRIPTION
```
Elo   | 1.20 +- 0.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 2.50]
Games | N: 129344 W: 31218 L: 30770 D: 67356
Penta | [424, 15327, 32733, 15753, 435]
```
https://furybench.com/test/1134/