### PR TITLE
Return alpha when no legal moves exist in singular search

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -1204,6 +1204,7 @@ Score Searcher::PVSearch(Thread &thread,
 
   // Terminal state if no legal moves were found
   if (moves_seen == 0) {
+    if (stack->excluded_tt_move) return alpha;
     return stack->in_check ? -kMateScore + stack->ply : kDrawScore;
   }
 


### PR DESCRIPTION
STC
```
Elo   | 2.31 +- 2.74 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 16406 W: 3975 L: 3866 D: 8565
Penta | [51, 1916, 4161, 2023, 52]
```
https://furybench.com/test/1417/

LTC
```
Elo   | 0.19 +- 1.33 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 62864 W: 14733 L: 14698 D: 33433
Penta | [50, 7254, 16810, 7247, 71]
```
https://furybench.com/test/1424/