### PR TITLE
Interpolate between fail-hard and fail-soft based on depth

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -1208,6 +1208,9 @@ Score Searcher::PVSearch(Thread &thread,
     return stack->in_check ? -kMateScore + stack->ply : kDrawScore;
   }
 
+  if (best_score >= beta && std::abs(best_score) < kTBWinInMaxPlyScore && std::abs(alpha) < kTBWinInMaxPlyScore)
+    best_score = (best_score * depth + beta) / (depth + 1);
+
   if (best_move) {
     // Since "good" captures are expected to be the best moves, we apply a
     // penalty to all captures even in the case where the best move was quiet


### PR DESCRIPTION
```
Elo   | 7.57 +- 3.81 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.52 (-2.25, 2.89) [0.00, 4.00]
Games | N: 8222 W: 2092 L: 1913 D: 4217
Penta | [18, 883, 2143, 1036, 31]
```
https://furybench.com/test/1556/

LTC
```
Elo   | 2.04 +- 1.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 4.00]
Games | N: 39954 W: 9850 L: 9615 D: 20489
Penta | [23, 4551, 10599, 4776, 28]
```
https://furybench.com/test/1559/