### PR TITLE
Correct LMR in very reduced nodes when static eval holds

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -699,6 +699,11 @@ Score Searcher::PVSearch(Thread &thread,
   (stack + 1)->ClearKillerMoves();
 
   if (!in_pv_node && !stack->in_check && stack->eval < kTBWinInMaxPlyScore) {
+    if (!stack->excluded_tt_move && prev_stack->reduction >= 4096 &&
+        !opponent_worsening) {
+      ++depth;
+    }
+
     const bool opponent_easy_capture = board.GetOpponentWinningCaptures() != 0;
 
     // Reverse (Static) Futility Pruning: Cutoff if we think the position
@@ -1079,6 +1084,8 @@ Score Searcher::PVSearch(Thread &thread,
         reduction -= kLmrKillerMoves;
       }
 
+      stack->reduction = reduction;
+
       // Scale reduction back down to an integer
       reduction = (reduction + kLmrRoundingCutoff) / kLmrScale;
       // Ensure the reduction doesn't give us a depth below 0
@@ -1088,6 +1095,8 @@ Score Searcher::PVSearch(Thread &thread,
       // Null window search at reduced depth to see if the move had potential
       score = -PVSearch<NodeType::kNonPV>(
           thread, new_depth - reduction, -alpha - 1, -alpha, stack + 1, true);
+
+      stack->reduction = 0;
 
       if ((needs_full_search = score > alpha && reduction != 0)) {
         // Search deeper or shallower depending on if the result of the

--- a/src/engine/search/stack.h
+++ b/src/engine/search/stack.h
@@ -75,6 +75,8 @@ struct StackEntry {
   bool in_check;
   // Threats
   BitBoard threats;
+  // Reduction applied for this ply
+  int reduction;
 
   void AddKillerMove(Move killer_move) {
     // Ensure we don't have duplicate killer moves
@@ -97,7 +99,8 @@ struct StackEntry {
         move(Move::NullMove()),
         excluded_tt_move(Move::NullMove()),
         killer_moves({}),
-        continuation_entry(nullptr) {
+        continuation_entry(nullptr),
+        reduction(0) {
     ClearKillerMoves();
   }
 


### PR DESCRIPTION
```
Elo   | 2.10 +- 1.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 2.50]
Games | N: 48686 W: 12139 L: 11845 D: 24702
Penta | [120, 5631, 12546, 5927, 119]
```
https://furybench.com/test/1601/