### PR TITLE
Fix capture history malus

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -1192,6 +1192,10 @@ Score Searcher::PVSearch(Thread &thread,
           } else if (is_capture) {
             history.capture_history->UpdateScore(state, move, history_depth);
           }
+          // Since "good" captures are expected to be the best moves, we apply a
+          // penalty to all captures even in the case where the best move was
+          // quiet
+          history.capture_history->Penalize(state, history_depth, captures);
           // Beta cutoff: The opponent had a better move earlier in the tree
           break;
         } else if (depth > 4 && depth < 10 && beta < kTBWinInMaxPlyScore &&
@@ -1220,17 +1224,12 @@ Score Searcher::PVSearch(Thread &thread,
       std::abs(alpha) < kTBWinInMaxPlyScore)
     best_score = (best_score * depth + beta) / (depth + 1);
 
-  if (best_move) {
-    // Since "good" captures are expected to be the best moves, we apply a
-    // penalty to all captures even in the case where the best move was quiet
-    history.capture_history->Penalize(state, depth, captures);
-  }
   // This node failed low, meaning the parent node will fail high. The previous
   // move will already be given a history bonus by the parent node in the beta
   // cutoff. However, we also give a history bonus in the event of a fail low to
   // allow history tweaks to occur in PVS re-searches
-  else if (prev_stack->move && !prev_stack->capture_move &&
-           prev_stack->move.GetType() != MoveType::kPromotion) {
+  if (!best_move && prev_stack->move && !prev_stack->capture_move &&
+      prev_stack->move.GetType() != MoveType::kPromotion) {
     const auto history_bonus = history::HistoryBonus(depth);
     const auto past_turn = FlipColor(state.turn);
     history.quiet_history->UpdateMoveScore(


### PR DESCRIPTION
```
Elo   | 1.17 +- 2.12 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 27086 W: 6790 L: 6699 D: 13597
Penta | [70, 3208, 6904, 3283, 78]
```
https://furybench.com/test/1688/