### PR TITLE
Play quiet moves in QS if the TT move was quiet and not from a fail-low

### DIFF
--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -36,7 +36,8 @@ MovePicker::MovePicker(MovePickerType type,
                        Move tt_move,
                        history::History &history,
                        StackEntry *stack,
-                       int see_threshold)
+                       int see_threshold,
+                       bool force_evasions)
     : board_(board),
       tt_move_(tt_move),
       type_(type),
@@ -44,7 +45,8 @@ MovePicker::MovePicker(MovePickerType type,
       stack_(stack),
       stage_(Stage::kTTMove),
       moves_idx_(0),
-      see_threshold_(see_threshold) {}
+      see_threshold_(see_threshold),
+      force_evasions_(force_evasions) {}
 
 Move MovePicker::Next() {
   const auto &state = board_.GetState();
@@ -82,7 +84,7 @@ Move MovePicker::Next() {
       bad_noisys_.Push({move, score});
     }
 
-    if (type_ == MovePickerType::kQuiescence && !state.InCheck()) {
+    if (type_ == MovePickerType::kQuiescence && !state.InCheck() && !force_evasions_) {
       return Move::NullMove();
     }
 

--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -56,7 +56,7 @@ Move MovePicker::Next() {
 
     if (tt_move_ && board_.IsMovePseudoLegal(tt_move_)) {
       if (type_ != MovePickerType::kQuiescence || state.InCheck() ||
-          tt_move_.IsNoisy(state)) {
+          tt_move_.IsNoisy(state) || force_evasions_) {
         return tt_move_;
       }
     }

--- a/src/engine/search/move_picker.h
+++ b/src/engine/search/move_picker.h
@@ -38,7 +38,8 @@ class MovePicker {
              Move tt_move,
              history::History &history,
              StackEntry *stack,
-             int see_threshold = 0);
+             int see_threshold = 0,
+             bool force_evasions = false);
 
   Move Next();
 
@@ -67,6 +68,7 @@ class MovePicker {
   List<ScoredMove, kMaxMoves> quiets_;
   int moves_idx_;
   int see_threshold_;
+  bool force_evasions_;
 };
 
 }  // namespace search

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -358,17 +358,17 @@ Score Searcher::QuiescentSearch(Thread &thread,
   Move best_move = Move::NullMove();
 
   const bool evasions =
-    !in_pv_node && tt_move &&
-    tt_entry->flag != TranspositionTableEntry::kUpperBound &&
-    !tt_move.IsNoisy(state);
+      !in_pv_node && tt_move &&
+      tt_entry->flag != TranspositionTableEntry::kUpperBound &&
+      !tt_move.IsNoisy(state);
 
   MovePicker move_picker(
-      MovePickerType::kQuiescence, board, tt_move, history, stack, evasions);
+      MovePickerType::kQuiescence, board, tt_move, history, stack, 0, evasions);
   while (const auto move = move_picker.Next()) {
     // Stop searching since all the good noisy moves have been searched,
     // unless we need to find a quiet evasion
     if (move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
-        moves_seen > 0 && !board.MoveGivesDirectCheck(move)) {
+        moves_seen > 2 * evasions && !board.MoveGivesDirectCheck(move)) {
       break;
     }
 

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -357,8 +357,13 @@ Score Searcher::QuiescentSearch(Thread &thread,
   MoveList quiets, captures;
   Move best_move = Move::NullMove();
 
+  const bool evasions =
+    !in_pv_node && tt_move &&
+    tt_entry->flag != TranspositionTableEntry::kUpperBound &&
+    !tt_move.IsNoisy(state);
+
   MovePicker move_picker(
-      MovePickerType::kQuiescence, board, tt_move, history, stack);
+      MovePickerType::kQuiescence, board, tt_move, history, stack, evasions);
   while (const auto move = move_picker.Next()) {
     // Stop searching since all the good noisy moves have been searched,
     // unless we need to find a quiet evasion

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -368,7 +368,7 @@ Score Searcher::QuiescentSearch(Thread &thread,
     // Stop searching since all the good noisy moves have been searched,
     // unless we need to find a quiet evasion
     if (move_picker.GetStage() > MovePicker::Stage::kGoodNoisys &&
-        moves_seen > 2 * evasions && !board.MoveGivesDirectCheck(move)) {
+        moves_seen > 0 && !board.MoveGivesDirectCheck(move)) {
       break;
     }
 


### PR DESCRIPTION
I think the Elo numbers here are largely inflated.

STC
```
Elo   | 5.93 +- 3.13 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.17 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12940 W: 3373 L: 3152 D: 6415
Penta | [47, 1449, 3276, 1632, 66]
```
https://furybench.com/test/5849/

LTC
```
Elo   | 11.59 +- 5.25 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 4078 W: 1051 L: 915 D: 2112
Penta | [5, 407, 1080, 541, 6]
```
https://furybench.com/test/5850/