### PR TITLE
Save to draw score to correction history if there's an upcoming repetition

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -518,11 +518,18 @@ Score Searcher::PVSearch(Thread &thread,
   }
 
   thread.sel_depth = std::max<U16>(thread.sel_depth, stack->ply);
+  stack->in_check = state.InCheck();
 
   // If the position has a move that causes a repetition, and we are losing,
   // then we can cut off early since we can secure a draw
   if (!in_root && alpha < kDrawScore &&
       board.HasUpcomingRepetition(stack->ply)) {
+    if (!stack->in_check) {
+      stack->static_eval =
+          AdjustStaticEval(eval::Evaluate(board), thread, stack);
+      history.correction_history->UpdateScore(
+          state, stack, kDrawScore, TranspositionTableEntry::kExact, depth);
+    }
     if ((alpha = kDrawScore) >= beta) {
       return alpha;
     }
@@ -533,8 +540,6 @@ Score Searcher::PVSearch(Thread &thread,
   if (depth == 0) {
     return QuiescentSearch<node_type>(thread, alpha, beta, stack);
   }
-
-  stack->in_check = state.InCheck();
 
   if (!in_root) {
     if (board.IsRepetition(stack->ply)) {
@@ -637,9 +642,8 @@ Score Searcher::PVSearch(Thread &thread,
     }
   }
 
-  Score raw_static_eval;
-
   // Approximate the current evaluation at this node
+  Score raw_static_eval;
   if (stack->in_check) {
     stack->static_eval = stack->eval = raw_static_eval = kScoreNone;
     stack->eval_complexity = 0;


### PR DESCRIPTION
STC
```
Elo   | 1.24 +- 1.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 2.50]
Games | N: 120112 W: 30260 L: 29830 D: 60022
Penta | [376, 14088, 30667, 14580, 345]
```
https://furybench.com/test/7121/

LTC
```
Elo   | 3.38 +- 2.11 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 2.50]
Games | N: 24494 W: 6009 L: 5771 D: 12714
Penta | [12, 2706, 6579, 2932, 18]
```
https://furybench.com/test/7125/

Credits to Hobbes author for this idea.