### PR TITLE
Small speedup in threat input updates

### DIFF
--- a/shared/simd.h
+++ b/shared/simd.h
@@ -102,12 +102,20 @@ namespace simd {
 
 #if BUILD_HAS_AVX512
 constexpr std::size_t kVectorBytes = 64;
+constexpr std::size_t kVectorRegisters = 32;
 #elif BUILD_HAS_AVX2
 constexpr std::size_t kVectorBytes = 32;
+constexpr std::size_t kVectorRegisters = 16;
 #elif BUILD_HAS_SSE41 || BUILD_HAS_NEON
 constexpr std::size_t kVectorBytes = 16;
+#if BUILD_HAS_NEON
+constexpr std::size_t kVectorRegisters = 32;
+#else
+constexpr std::size_t kVectorRegisters = 16;
+#endif
 #else
 constexpr std::size_t kVectorBytes = 16;
+constexpr std::size_t kVectorRegisters = 16;
 #endif
 
 constexpr std::size_t kAlignment = kVectorBytes < 16 ? 16 : kVectorBytes;

--- a/src/engine/evaluation/nnue/perspective_accumulator.h
+++ b/src/engine/evaluation/nnue/perspective_accumulator.h
@@ -69,15 +69,19 @@ class PerspectiveAccumulator {
                    int num_adds,
                    Weight const* const* subs,
                    int num_subs) {
-    using namespace simd;
-
+    // We process the accumulation of size kWidth elements, in chunks of
+    // kBlockVecs SIMD registers, to avoid unnecessary loads and stores
+    // from register spills.
     constexpr int kBlockVecs = 8;
-    constexpr int kElementsPerVec = kVectorBytes / sizeof(I16);
+    // Always accumulate in i16
+    constexpr int kElementsPerVec = simd::kVectorBytes / sizeof(I16);
     constexpr int kElementsPerBlock = kElementsPerVec * kBlockVecs;
     constexpr int kBlockCount = kWidth / kElementsPerBlock;
 
     static_assert(kWidth % kElementsPerBlock == 0, "must evenly divide");
 
+    // i = block index; K = element index of start of the block;
+    // j = vector index within block; k = element index
     for (int i = 0, K = 0; i < kBlockCount; ++i, K += kElementsPerBlock) {
       simd::Vepi16 vecs[kBlockVecs];
       for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
@@ -87,14 +91,20 @@ class PerspectiveAccumulator {
       for (int add_i = 0; add_i < num_adds; ++add_i) {
         const auto* feature = adds[add_i];
         for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
-          vecs[j] = vecs[j] + Convert<I16>(simd::Load<Weight, kElementsPerVec>(&feature[k]));
+          // Conversion is required from I8 weights and is a no-op for I16
+          // weights
+          vecs[j] =
+              vecs[j] + simd::Convert<I16>(
+                            simd::Load<Weight, kElementsPerVec>(&feature[k]));
         }
       }
 
       for (int sub_i = 0; sub_i < num_subs; ++sub_i) {
         const auto* feature = subs[sub_i];
         for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
-          vecs[j] = vecs[j] - Convert<I16>(simd::Load<Weight, kElementsPerVec>(&feature[k]));
+          vecs[j] =
+              vecs[j] - simd::Convert<I16>(
+                            simd::Load<Weight, kElementsPerVec>(&feature[k]));
         }
       }
 

--- a/src/engine/evaluation/nnue/perspective_accumulator.h
+++ b/src/engine/evaluation/nnue/perspective_accumulator.h
@@ -69,41 +69,37 @@ class PerspectiveAccumulator {
                    int num_adds,
                    Weight const* const* subs,
                    int num_subs) {
-    if (this != &previous) {
-      for (int i = 0; i < kWidth; ++i) {
-        values_[i] = previous.values_[i];
+    using namespace simd;
+
+    constexpr int kBlockVecs = 8;
+    constexpr int kElementsPerVec = kVectorBytes / sizeof(I16);
+    constexpr int kElementsPerBlock = kElementsPerVec * kBlockVecs;
+    constexpr int kBlockCount = kWidth / kElementsPerBlock;
+
+    static_assert(kWidth % kElementsPerBlock == 0, "must evenly divide");
+
+    for (int i = 0, K = 0; i < kBlockCount; ++i, K += kElementsPerBlock) {
+      simd::Vepi16 vecs[kBlockVecs];
+      for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
+        vecs[j] = simd::Load(&previous.values_[k]);
       }
-    }
-    // Pair up adds and subs while both are available, so the accumulator is
-    // only read and written back once per group of eight rows
-    for (; num_adds >= 4 && num_subs >= 4; num_adds -= 4, num_subs -= 4) {
-      for (int i = 0; i < kWidth; ++i) {
-        values_[i] += adds[num_adds - 4][i] + adds[num_adds - 3][i] +
-                      adds[num_adds - 2][i] + adds[num_adds - 1][i] -
-                      subs[num_subs - 4][i] - subs[num_subs - 3][i] -
-                      subs[num_subs - 2][i] - subs[num_subs - 1][i];
+
+      for (int add_i = 0; add_i < num_adds; ++add_i) {
+        const auto* feature = adds[add_i];
+        for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
+          vecs[j] = vecs[j] + Convert<I16>(simd::Load<Weight, kElementsPerVec>(&feature[k]));
+        }
       }
-    }
-    for (; num_adds >= 4; num_adds -= 4) {
-      for (int i = 0; i < kWidth; ++i) {
-        values_[i] += adds[num_adds - 4][i] + adds[num_adds - 3][i] +
-                      adds[num_adds - 2][i] + adds[num_adds - 1][i];
+
+      for (int sub_i = 0; sub_i < num_subs; ++sub_i) {
+        const auto* feature = subs[sub_i];
+        for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
+          vecs[j] = vecs[j] - Convert<I16>(simd::Load<Weight, kElementsPerVec>(&feature[k]));
+        }
       }
-    }
-    for (; num_adds >= 1; num_adds -= 1) {
-      for (int i = 0; i < kWidth; ++i) {
-        values_[i] += adds[num_adds - 1][i];
-      }
-    }
-    for (; num_subs >= 4; num_subs -= 4) {
-      for (int i = 0; i < kWidth; ++i) {
-        values_[i] -= subs[num_subs - 4][i] + subs[num_subs - 3][i] +
-                      subs[num_subs - 2][i] + subs[num_subs - 1][i];
-      }
-    }
-    for (; num_subs >= 1; num_subs -= 1) {
-      for (int i = 0; i < kWidth; ++i) {
-        values_[i] -= subs[num_subs - 1][i];
+
+      for (int j = 0, k = K; j < kBlockVecs; ++j, k += kElementsPerVec) {
+        simd::Store(&values_[k], vecs[j]);
       }
     }
   }


### PR DESCRIPTION
```
ELO    4.21 +- 2.55 (95%)
SPRT   10.0+0.10s Threads=1 Hash=16MB
LLR    2.94 (-2.25, 2.89) [0.00, 3.00]
GAMES  N: 15926 W: 4075 L: 3882 D: 7969
PENTA  [25, 1564, 4606, 1729, 39]
```

https://furybench.com/test/7354/

Bench: 2170032