### PR TITLE
Add half-move count inputs to the network

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(BUILD_SSE41_POPCNT "Build with SSE4.1 + POPCNT optimizations" OFF)
 option(BUILD_DEBUG "Build with debug information" OFF)
 
 # Allow user to specify EVALFILE through CMake
-set(NETWORK_NAME vaporeon)
+set(NETWORK_NAME hmc)
 set(EVALFILE "${EVALFILE}" CACHE STRING "Path to the evaluation (.nnue) file")
 set(NNUE_URL "https://github.com/aronpetko/integral-networks/releases/download/${NETWORK_NAME}/${NETWORK_NAME}.nnue")
 set(NNUE_PATH "${PROJECT_SOURCE_DIR}/${NETWORK_NAME}.nnue")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(BUILD_SSE41_POPCNT "Build with SSE4.1 + POPCNT optimizations" OFF)
 option(BUILD_DEBUG "Build with debug information" OFF)
 
 # Allow user to specify EVALFILE through CMake
-set(NETWORK_NAME hmc)
+set(NETWORK_NAME haxorus)
 set(EVALFILE "${EVALFILE}" CACHE STRING "Path to the evaluation (.nnue) file")
 set(NNUE_URL "https://github.com/aronpetko/integral-networks/releases/download/${NETWORK_NAME}/${NETWORK_NAME}.nnue")
 set(NNUE_PATH "${PROJECT_SOURCE_DIR}/${NETWORK_NAME}.nnue")

--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ Integral implements the widely adopted negamax search approach with alpha-beta p
 Integral utilizes an efficiently updatable neural network (NNUE) for its evaluation function.
 
 ### Architecture
-Integral's neural network is a horizontally mirrored perspective network, containing 12 factorized king input buckets, an L1 of 1536 neurons, an L2 of 16 neurons, an L3 of 32 neurons, and 8 output buckets.
-`(768x12 (Factorized) -> 1536)x2 -> (16 -> 32 -> 1)1x8`
+Integral's neural network is a horizontally mirrored perspective network, containing 12 factorized king input buckets with threat inputs and fifty-move rule inputs, an L1 of 768 neurons, an L2 of 16 neurons, an L3 of 32 neurons, and 8 output buckets.
+
+`[(768 + 1x11)x12hm (Factorized) + 60144hm -> 768]x2 -> (16 -> 32 -> 1)1x8`
 
 ### Data Generation Process
-This neural network is trained on tens of millions of self-play games. Each self-play game starts with 3-4 randomly selected moves off a randomly selected opening from the **UHO_Lichess_4852_v1** book. Additionally, 5-man Syzygy endgame tablebases are used to guide the data generation search. 
+This neural network is trained on hundreds of millions of self-play games. Most self-play games starts with 3-4 randomly selected moves off a randomly selected opening from the **UHO_Lichess_4852_v1** book. Additionally, a majority of the data uses 5-man Syzygy endgame tablebases to guide the data generation search. 
 
 ### Training Process
-The first iteration of Integral's neural network was trained on data from version 4, which had a powerful hand-crafted evaluation (HCE). Each iteration of Integral's neural network since then has been trained on a fresh dataset using the prior network.
-All networks are trained using the <a href="https://github.com/jw1912/bullet">Bullet</a> trainer, which has made my life way easier. 
+The first iteration of Integral's neural network was trained on data from version 4, which had a powerful hand-crafted evaluation (HCE). All early-network data has been thrown out and a majority of Integral's data is generated using a search of 20k soft-nodes per-side. The datasets Integral trains on is publicy available through my [Huggingface repository](https://huggingface.co/aronpetkovski/integral-datasets/tree/main).
+Networks are trained using the <a href="https://github.com/jw1912/bullet">Bullet</a> trainer.
 
 ## Compiling Integral
 > [!NOTE]  

--- a/preprocess/net_processing.cc
+++ b/preprocess/net_processing.cc
@@ -11,7 +11,9 @@ std::unique_ptr<nnue::Network> ProcessNetwork(
   // Copy over arrays that don't need transposing
   for (int b = 0; b < nnue::arch::kInputBucketCount; ++b) {
     network->feature_weights[b] = raw_network->input_buckets[b].feature_weights;
-    network->hmc_weights[b] = raw_network->input_buckets[b].hmc_weights;
+    for (int h = 0; h < nnue::arch::kHmcBucketCount; ++h) {
+      network->hmc_weights[b][h] = raw_network->input_buckets[b].hmc_weights[h];
+    }
   }
   network->feature_biases = raw_network->feature_biases;
   network->threat_weights = raw_network->threat_weights;
@@ -41,9 +43,8 @@ std::unique_ptr<nnue::Network> ProcessNetwork(
   }
 
   auto hmc = reinterpret_cast<__m128i*>(&network->hmc_weights);
-  for (int i = 0;
-       i < nnue::arch::kInputBucketCount * nnue::arch::kHmcBucketCount *
-               nnue::arch::kL1Size / kWeightsPerBlock;
+  for (int i = 0; i < nnue::arch::kInputBucketCount * nnue::arch::kHmcRowCount *
+                          nnue::arch::kL1Size / kWeightsPerBlock;
        i += kNumRegs) {
     for (int j = 0; j < kNumRegs; j++) regs[j] = hmc[i + j];
 

--- a/preprocess/net_processing.cc
+++ b/preprocess/net_processing.cc
@@ -8,8 +8,13 @@ std::unique_ptr<nnue::Network> ProcessNetwork(
     const std::unique_ptr<nnue::RawNetwork>& raw_network) {
   auto network = std::make_unique<nnue::Network>();
 
-  // Copy over arrays that don't need transposing
-  network->feature_weights = raw_network->feature_weights;
+  // Copy over arrays that don't need transposing. The input buckets arrive
+  // interleaved (768 piece rows then kHmcBucketCount 50mr rows, per bucket), so
+  // they get split into the two arrays the engine indexes separately.
+  for (int b = 0; b < nnue::arch::kInputBucketCount; ++b) {
+    network->feature_weights[b] = raw_network->input_buckets[b].feature_weights;
+    network->hmc_weights[b] = raw_network->input_buckets[b].hmc_weights;
+  }
   network->feature_biases = raw_network->feature_biases;
   network->threat_weights = raw_network->threat_weights;
 
@@ -35,6 +40,18 @@ std::unique_ptr<nnue::Network> ProcessNetwork(
 
     for (int j = 0; j < kNumRegs; j++)
       biases[i + j] = regs[simd::kPackusOrder[j]];
+  }
+
+  // The 50mr rows land in the same accumulator lanes as the FT weights, so they
+  // need the identical shuffle
+  auto hmc = reinterpret_cast<__m128i*>(&network->hmc_weights);
+  for (int i = 0; i < nnue::arch::kInputBucketCount *
+                          nnue::arch::kHmcBucketCount * nnue::arch::kL1Size /
+                          kWeightsPerBlock;
+       i += kNumRegs) {
+    for (int j = 0; j < kNumRegs; j++) regs[j] = hmc[i + j];
+
+    for (int j = 0; j < kNumRegs; j++) hmc[i + j] = regs[simd::kPackusOrder[j]];
   }
 
   // Same 8-element granularity as the FT weights, but I8 rows -> 8-byte blocks.

--- a/preprocess/net_processing.cc
+++ b/preprocess/net_processing.cc
@@ -8,9 +8,7 @@ std::unique_ptr<nnue::Network> ProcessNetwork(
     const std::unique_ptr<nnue::RawNetwork>& raw_network) {
   auto network = std::make_unique<nnue::Network>();
 
-  // Copy over arrays that don't need transposing. The input buckets arrive
-  // interleaved (768 piece rows then kHmcBucketCount 50mr rows, per bucket), so
-  // they get split into the two arrays the engine indexes separately.
+  // Copy over arrays that don't need transposing
   for (int b = 0; b < nnue::arch::kInputBucketCount; ++b) {
     network->feature_weights[b] = raw_network->input_buckets[b].feature_weights;
     network->hmc_weights[b] = raw_network->input_buckets[b].hmc_weights;
@@ -42,12 +40,10 @@ std::unique_ptr<nnue::Network> ProcessNetwork(
       biases[i + j] = regs[simd::kPackusOrder[j]];
   }
 
-  // The 50mr rows land in the same accumulator lanes as the FT weights, so they
-  // need the identical shuffle
   auto hmc = reinterpret_cast<__m128i*>(&network->hmc_weights);
-  for (int i = 0; i < nnue::arch::kInputBucketCount *
-                          nnue::arch::kHmcBucketCount * nnue::arch::kL1Size /
-                          kWeightsPerBlock;
+  for (int i = 0;
+       i < nnue::arch::kInputBucketCount * nnue::arch::kHmcBucketCount *
+               nnue::arch::kL1Size / kWeightsPerBlock;
        i += kNumRegs) {
     for (int j = 0; j < kNumRegs; j++) regs[j] = hmc[i + j];
 

--- a/shared/nnue/definitions.h
+++ b/shared/nnue/definitions.h
@@ -30,9 +30,7 @@ constexpr std::int32_t kEvalScale = 200;
 }  // namespace arch
 
 // clang-format off
-// The trainer writes l0/psqt as one matrix with a stride of (768 + kHmcBucketCount)
-// columns per king bucket, so the 50mr rows are interleaved into each bucket rather
-// than sitting in a block of their own. `preprocess` splits them back apart.
+
 struct RawInputBucket {
   MultiArray<I16, 2, PieceType::kNumPieceTypes, Squares::kSquareCount, arch::kL1Size> feature_weights;
   MultiArray<I16, arch::kHmcBucketCount, arch::kL1Size> hmc_weights;

--- a/shared/nnue/definitions.h
+++ b/shared/nnue/definitions.h
@@ -19,6 +19,9 @@ constexpr std::size_t kHmcBucketsStart = 14;
 constexpr std::size_t kHmcBucketsStep = 8;
 constexpr std::size_t kHmcBucketCount =
     (100 - kHmcBucketsStart + kHmcBucketsStep - 1) / kHmcBucketsStep;
+// The runtime network carries one extra, all-zero row that a bucket-0 HMC maps
+// to, so looking up the row is a table index with no branch
+constexpr std::size_t kHmcRowCount = kHmcBucketCount + 1;
 constexpr std::size_t kInputBucketCount = 12;
 constexpr std::size_t kOutputBucketCount = 8;
 
@@ -50,7 +53,7 @@ struct RawNetwork {
 
 struct alignas(simd::kAlignment) Network {
   alignas(simd::kAlignment) MultiArray<I16, arch::kInputBucketCount, 2, PieceType::kNumPieceTypes, Squares::kSquareCount, arch::kL1Size> feature_weights;
-  alignas(simd::kAlignment) MultiArray<I16, arch::kInputBucketCount, arch::kHmcBucketCount, arch::kL1Size> hmc_weights;
+  alignas(simd::kAlignment) MultiArray<I16, arch::kInputBucketCount, arch::kHmcRowCount, arch::kL1Size> hmc_weights;
   alignas(simd::kAlignment) MultiArray<I8, arch::kThreatFeatureCount, arch::kL1Size> threat_weights;
   alignas(simd::kAlignment) MultiArray<I16, arch::kL1Size> feature_biases;
   union {

--- a/shared/nnue/definitions.h
+++ b/shared/nnue/definitions.h
@@ -14,6 +14,11 @@ constexpr std::size_t kThreatFeatureCount = 60144;
 constexpr std::size_t kL1Size = 768;
 constexpr std::size_t kL2Size = 16;
 constexpr std::size_t kL3Size = 32;
+
+constexpr std::size_t kHmcBucketsStart = 14;
+constexpr std::size_t kHmcBucketsStep = 8;
+constexpr std::size_t kHmcBucketCount =
+    (100 - kHmcBucketsStart + kHmcBucketsStep - 1) / kHmcBucketsStep;
 constexpr std::size_t kInputBucketCount = 12;
 constexpr std::size_t kOutputBucketCount = 8;
 
@@ -25,8 +30,16 @@ constexpr std::int32_t kEvalScale = 200;
 }  // namespace arch
 
 // clang-format off
+// The trainer writes l0/psqt as one matrix with a stride of (768 + kHmcBucketCount)
+// columns per king bucket, so the 50mr rows are interleaved into each bucket rather
+// than sitting in a block of their own. `preprocess` splits them back apart.
+struct RawInputBucket {
+  MultiArray<I16, 2, PieceType::kNumPieceTypes, Squares::kSquareCount, arch::kL1Size> feature_weights;
+  MultiArray<I16, arch::kHmcBucketCount, arch::kL1Size> hmc_weights;
+};
+
 struct RawNetwork {
-  MultiArray<I16, arch::kInputBucketCount, 2, PieceType::kNumPieceTypes, Squares::kSquareCount, arch::kL1Size> feature_weights;
+  std::array<RawInputBucket, arch::kInputBucketCount> input_buckets;
   MultiArray<I8, arch::kThreatFeatureCount, arch::kL1Size> threat_weights;
   MultiArray<I16, arch::kL1Size> feature_biases;
   MultiArray<I8, arch::kOutputBucketCount, arch::kL2Size, arch::kL1Size> l1_weights;
@@ -39,6 +52,7 @@ struct RawNetwork {
 
 struct alignas(simd::kAlignment) Network {
   alignas(simd::kAlignment) MultiArray<I16, arch::kInputBucketCount, 2, PieceType::kNumPieceTypes, Squares::kSquareCount, arch::kL1Size> feature_weights;
+  alignas(simd::kAlignment) MultiArray<I16, arch::kInputBucketCount, arch::kHmcBucketCount, arch::kL1Size> hmc_weights;
   alignas(simd::kAlignment) MultiArray<I8, arch::kThreatFeatureCount, arch::kL1Size> threat_weights;
   alignas(simd::kAlignment) MultiArray<I16, arch::kL1Size> feature_biases;
   union {

--- a/src/engine/evaluation/nnue/accumulator.h
+++ b/src/engine/evaluation/nnue/accumulator.h
@@ -68,6 +68,21 @@ class Accumulator {
 
   [[nodiscard]] int GetOutputBucket(const BoardState& state) const;
 
+  [[nodiscard]] const I16* HmcRow(Color perspective, U16 clock) const {
+    alignas(simd::kAlignment) static constexpr std::array<I16, arch::kL1Size>
+        kZeroRow{};
+
+    const int hmc_bucket = HmcBucket(clock);
+    if (hmc_bucket < 0) {
+      return kZeroRow.data();
+    }
+
+    const auto king_square = stack_[head_idx_].kings[perspective];
+    return network
+        ->hmc_weights[GetKingBucket(king_square, perspective)][hmc_bucket]
+        .data();
+  }
+
   [[nodiscard]] PerspectiveView operator[](int perspective) {
     auto& entry = stack_[head_idx_];
     return {entry.psqt_perspectives[perspective],

--- a/src/engine/evaluation/nnue/accumulator.h
+++ b/src/engine/evaluation/nnue/accumulator.h
@@ -68,19 +68,11 @@ class Accumulator {
 
   [[nodiscard]] int GetOutputBucket(const BoardState& state) const;
 
-  [[nodiscard]] const I16* HmcRow(Color perspective, U16 clock) const {
-    alignas(simd::kAlignment) static constexpr std::array<I16, arch::kL1Size>
-        kZeroRow{};
-
-    const int hmc_bucket = HmcBucket(clock);
-    if (hmc_bucket < 0) {
-      return kZeroRow.data();
-    }
-
+  [[nodiscard]] const I16* HmcRow(Color perspective, int hmc_row) const {
     const auto king_square = stack_[head_idx_].kings[perspective];
-    return network
-        ->hmc_weights[GetKingBucket(king_square, perspective)][hmc_bucket]
-        .data();
+    return network->hmc_weights[GetKingBucket(king_square, perspective)]
+                              [hmc_row]
+                                  .data();
   }
 
   [[nodiscard]] PerspectiveView operator[](int perspective) {

--- a/src/engine/evaluation/nnue/nnue.cc
+++ b/src/engine/evaluation/nnue/nnue.cc
@@ -41,6 +41,7 @@ Score Evaluate(Board &board) {
 
   accumulator.ApplyChanges(state);
   const auto bucket = accumulator.GetOutputBucket(state);
+  const int hmc_bucket = GetHmcBucket(state.fifty_moves_clock);
 
   constexpr int kFtShift = 9;
 
@@ -59,85 +60,92 @@ Score Evaluate(Board &board) {
 
   // Activate the feature layer neurons
   alignas(simd::kAlignment) std::array<U8, arch::kL1Size> feature_output;
-  for (int them = 0; them <= 1; them++) {
-    const auto perspective = static_cast<Color>(state.turn ^ them);
-    const auto &stm_accumulator = accumulator[perspective];
-    // The 50mr feature is a single row rather than an accumulated sum, so it's
-    // read here instead of being folded into the accumulator
-    const I16 *hmc = accumulator.HmcRow(perspective, state.fifty_moves_clock);
-    for (int i = 0; i < arch::kL1Size / 2; i += kI8Lanes) {
-      // Clip first accumulator values
-      const auto accumulator_value =
-          simd::Load<I16>(&stm_accumulator.psqt[i]) +
-          simd::Load<I16>(&stm_accumulator.threat[i]) +
-          simd::Load<I16>(&hmc[i]);
-      const auto pair_accumulator_value =
-          simd::Load<I16>(&stm_accumulator.psqt[i + arch::kL1Size / 2]) +
-          simd::Load<I16>(&stm_accumulator.threat[i + arch::kL1Size / 2]) +
-          simd::Load<I16>(&hmc[i + arch::kL1Size / 2]);
+  const auto transform_features = [&]<bool kHasHmc>() {
+    for (int them = 0; them <= 1; them++) {
+      const auto perspective = static_cast<Color>(state.turn ^ them);
+      const auto &stm_accumulator = accumulator[perspective];
+      const auto hmc =
+          kHasHmc ? accumulator.HmcRow(perspective, hmc_bucket) : nullptr;
 
-      const auto clipped_value =
-          simd::Clip(accumulator_value, arch::kFtQuantization);
-      const auto clipped_pair_value =
-          simd::Min(pair_accumulator_value, quantise_vector);
+      const auto load_neurons = [&](int idx) {
+        auto value = simd::Load<I16>(&stm_accumulator.psqt[idx]) +
+                     simd::Load<I16>(&stm_accumulator.threat[idx]);
+        if constexpr (kHasHmc) {
+          value = value + simd::Load<I16>(&hmc[idx]);
+        }
+        return value;
+      };
 
-      // Clip second accumulator values
-      const auto accumulator_value1 =
-          simd::Load<I16>(&stm_accumulator.psqt[i + kI16Lanes]) +
-          simd::Load<I16>(&stm_accumulator.threat[i + kI16Lanes]) +
-          simd::Load<I16>(&hmc[i + kI16Lanes]);
-      const auto pair_accumulator_value1 =
-          simd::Load<I16>(
-              &stm_accumulator.psqt[i + arch::kL1Size / 2 + kI16Lanes]) +
-          simd::Load<I16>(
-              &stm_accumulator.threat[i + arch::kL1Size / 2 + kI16Lanes]) +
-          simd::Load<I16>(&hmc[i + arch::kL1Size / 2 + kI16Lanes]);
-      const auto clipped_value1 =
-          simd::Clip(accumulator_value1, arch::kFtQuantization);
-      const auto clipped_pair_value1 =
-          simd::Min(pair_accumulator_value1, quantise_vector);
+      for (int i = 0; i < arch::kL1Size / 2; i += kI8Lanes) {
+        // Clip first accumulator values
+        const auto accumulator_value = load_neurons(i);
+        const auto pair_accumulator_value = load_neurons(i + arch::kL1Size / 2);
 
-      // Perform a left-shift on them and multiply the products using the
-      // higher 16 bits
-      const auto first_product = simd::MulhiEpi16(
-          clipped_value << (16 - kFtShift), clipped_pair_value);
-      const auto second_product = simd::MulhiEpi16(
-          clipped_value1 << (16 - kFtShift), clipped_pair_value1);
+        const auto clipped_value =
+            simd::Clip(accumulator_value, arch::kFtQuantization);
+        const auto clipped_pair_value =
+            simd::Min(pair_accumulator_value, quantise_vector);
 
-      // Pack the two I16 vectors into a U8 vector, which will clamp negative
-      // values to 0 because of unsigned saturation. This is why we didn't clamp
-      // the pair values to 0 earlier, effectively saving us an operation
-      auto &features =
-          simd::AsVector<U8>(&feature_output[i + them * arch::kL1Size / 2]);
-      features = simd::PackusEpi16(first_product, second_product);
+        // Clip second accumulator values
+        const auto accumulator_value1 = load_neurons(i + kI16Lanes);
+        const auto pair_accumulator_value1 =
+            load_neurons(i + arch::kL1Size / 2 + kI16Lanes);
+        const auto clipped_value1 =
+            simd::Clip(accumulator_value1, arch::kFtQuantization);
+        const auto clipped_pair_value1 =
+            simd::Min(pair_accumulator_value1, quantise_vector);
 
-      // Sparse Processing, or NNZ (Number of Non-Zero), is an optimization we
-      // perform to minimize the amount of computation done by only mat-mulling
-      // the positive, non-zero activated features with the next layer's weights
-      // -----------------------------------------------------------------------
-      // Get a mask of all positive, non-zero elements
-      // Each bit in `nnz_mask` corresponds to whether a specific feature is
-      // positive (1) or zero (0)
-      const auto nnz_mask = simd::NonZeroMask(simd::Cast<I32>(features));
-      // Loop through 8-bit (U8) slices of this 16-bit mask
-      for (int chunk = 0; chunk < kI32Lanes; chunk += 8) {
-        // Extract the 8-bit slice from the mask
-        const U8 slice = (nnz_mask >> chunk) & 0b11111111;
-        // Lookup the relative indices for each set bit in the mask, essentially
-        // retrieving the indices for each positive element as an 8-element
-        // vector of I16s
-        const auto indices =
-            simd::Load<U16, 8>(sparse::nnz_table[slice].indices.data());
-        // Store these absolute indices into our table. We account for the fact
-        // that they are relative indices (to this slice) by adding `nnz_base`,
-        // which will reflect the position each element is in the entire table
-        simd::Store<U16, 8>(&nnz_indices[nnz_count], nnz_base + indices);
-        // Update to reflect the total number of non-zero features processed
-        nnz_count += BitBoard(slice).PopCount();
-        // Increment to reflect the starting index of the next slice
-        nnz_base += lookup_increment;
+        // Perform a left-shift on them and multiply the products using the
+        // higher 16 bits
+        const auto first_product = simd::MulhiEpi16(
+            clipped_value << (16 - kFtShift), clipped_pair_value);
+        const auto second_product = simd::MulhiEpi16(
+            clipped_value1 << (16 - kFtShift), clipped_pair_value1);
+
+        // Pack the two I16 vectors into a U8 vector, which will clamp negative
+        // values to 0 because of unsigned saturation. This is why we didn't
+        // clamp the pair values to 0 earlier, effectively saving us an
+        // operation
+        auto &features =
+            simd::AsVector<U8>(&feature_output[i + them * arch::kL1Size / 2]);
+        features = simd::PackusEpi16(first_product, second_product);
+
+        // Sparse Processing, or NNZ (Number of Non-Zero), is an optimization we
+        // perform to minimize the amount of computation done by only
+        // mat-mulling the positive, non-zero activated features with the next
+        // layer's weights
+        // -----------------------------------------------------------------------
+        // Get a mask of all positive, non-zero elements
+        // Each bit in `nnz_mask` corresponds to whether a specific feature is
+        // positive (1) or zero (0)
+        const auto nnz_mask = simd::NonZeroMask(simd::Cast<I32>(features));
+        // Loop through 8-bit (U8) slices of this 16-bit mask
+        for (int chunk = 0; chunk < kI32Lanes; chunk += 8) {
+          // Extract the 8-bit slice from the mask
+          const U8 slice = (nnz_mask >> chunk) & 0b11111111;
+          // Lookup the relative indices for each set bit in the mask,
+          // essentially retrieving the indices for each positive element as an
+          // 8-element vector of I16s
+          const auto indices =
+              simd::Load<U16, 8>(sparse::nnz_table[slice].indices.data());
+          // Store these absolute indices into our table. We account for the
+          // fact that they are relative indices (to this slice) by adding
+          // `nnz_base`, which will reflect the position each element is in the
+          // entire table
+          simd::Store<U16, 8>(&nnz_indices[nnz_count], nnz_base + indices);
+          // Update to reflect the total number of non-zero features processed
+          nnz_count += BitBoard(slice).PopCount();
+          // Increment to reflect the starting index of the next slice
+          nnz_base += lookup_increment;
+        }
       }
     }
+  };
+
+  if (hmc_bucket == arch::kHmcBucketCount) {
+    transform_features.template operator()<false>();
+  } else {
+    transform_features.template operator()<true>();
   }
 
 #ifdef SPARSE_PERMUTE
@@ -245,7 +253,7 @@ Score Evaluate(Board &board) {
   for (int them = 0; them <= 1; them++) {
     const auto perspective = static_cast<Color>(state.turn ^ them);
     const auto &stm_accumulator = accumulator[perspective];
-    const I16 *hmc = accumulator.HmcRow(perspective, state.fifty_moves_clock);
+    const I16 *hmc = accumulator.HmcRow(perspective, hmc_bucket);
     for (int i = 0; i < arch::kL1Size / 2; i++) {
       const auto first_val = CReLU(static_cast<I16>(
           stm_accumulator.psqt[i] + stm_accumulator.threat[i] + hmc[i]));

--- a/src/engine/evaluation/nnue/nnue.cc
+++ b/src/engine/evaluation/nnue/nnue.cc
@@ -60,15 +60,21 @@ Score Evaluate(Board &board) {
   // Activate the feature layer neurons
   alignas(simd::kAlignment) std::array<U8, arch::kL1Size> feature_output;
   for (int them = 0; them <= 1; them++) {
-    const auto &stm_accumulator = accumulator[state.turn ^ them];
+    const auto perspective = static_cast<Color>(state.turn ^ them);
+    const auto &stm_accumulator = accumulator[perspective];
+    // The 50mr feature is a single row rather than an accumulated sum, so it's
+    // read here instead of being folded into the accumulator
+    const I16 *hmc = accumulator.HmcRow(perspective, state.fifty_moves_clock);
     for (int i = 0; i < arch::kL1Size / 2; i += kI8Lanes) {
       // Clip first accumulator values
       const auto accumulator_value =
           simd::Load<I16>(&stm_accumulator.psqt[i]) +
-          simd::Load<I16>(&stm_accumulator.threat[i]);
+          simd::Load<I16>(&stm_accumulator.threat[i]) +
+          simd::Load<I16>(&hmc[i]);
       const auto pair_accumulator_value =
           simd::Load<I16>(&stm_accumulator.psqt[i + arch::kL1Size / 2]) +
-          simd::Load<I16>(&stm_accumulator.threat[i + arch::kL1Size / 2]);
+          simd::Load<I16>(&stm_accumulator.threat[i + arch::kL1Size / 2]) +
+          simd::Load<I16>(&hmc[i + arch::kL1Size / 2]);
 
       const auto clipped_value =
           simd::Clip(accumulator_value, arch::kFtQuantization);
@@ -78,12 +84,14 @@ Score Evaluate(Board &board) {
       // Clip second accumulator values
       const auto accumulator_value1 =
           simd::Load<I16>(&stm_accumulator.psqt[i + kI16Lanes]) +
-          simd::Load<I16>(&stm_accumulator.threat[i + kI16Lanes]);
+          simd::Load<I16>(&stm_accumulator.threat[i + kI16Lanes]) +
+          simd::Load<I16>(&hmc[i + kI16Lanes]);
       const auto pair_accumulator_value1 =
           simd::Load<I16>(
               &stm_accumulator.psqt[i + arch::kL1Size / 2 + kI16Lanes]) +
           simd::Load<I16>(
-              &stm_accumulator.threat[i + arch::kL1Size / 2 + kI16Lanes]);
+              &stm_accumulator.threat[i + arch::kL1Size / 2 + kI16Lanes]) +
+          simd::Load<I16>(&hmc[i + arch::kL1Size / 2 + kI16Lanes]);
       const auto clipped_value1 =
           simd::Clip(accumulator_value1, arch::kFtQuantization);
       const auto clipped_pair_value1 =
@@ -235,10 +243,16 @@ Score Evaluate(Board &board) {
   // Activate the feature layer via pair-wise CReLU multiplication
   std::array<U8, arch::kL1Size> feature_output{};
   for (int them = 0; them <= 1; them++) {
-    const auto &stm_accumulator = accumulator[state.turn ^ them];
+    const auto perspective = static_cast<Color>(state.turn ^ them);
+    const auto &stm_accumulator = accumulator[perspective];
+    const I16 *hmc = accumulator.HmcRow(perspective, state.fifty_moves_clock);
     for (int i = 0; i < arch::kL1Size / 2; i++) {
-      const auto first_val = CReLU(stm_accumulator[i]);
-      const auto second_val = CReLU(stm_accumulator[i + arch::kL1Size / 2]);
+      const auto first_val = CReLU(static_cast<I16>(
+          stm_accumulator.psqt[i] + stm_accumulator.threat[i] + hmc[i]));
+      const auto second_val =
+          CReLU(static_cast<I16>(stm_accumulator.psqt[i + arch::kL1Size / 2] +
+                                 stm_accumulator.threat[i + arch::kL1Size / 2] +
+                                 hmc[i + arch::kL1Size / 2]));
 
       const auto product = (first_val * second_val) >> 9;
       feature_output[i + them * arch::kL1Size / 2] = static_cast<U8>(product);
@@ -296,8 +310,7 @@ Score Evaluate(Board &board) {
   }
 
   const float l3_output =
-      network->l3_biases[bucket] +
-      simd::ReduceAddPsRecursive(result_sums.data(), kResultChunks);
+      network->l3_biases[bucket] + simd::ReduceAdd(result_sums);
 
   // Scale output
   return static_cast<Score>(l3_output * arch::kEvalScale);

--- a/src/engine/evaluation/nnue/perspective_accumulator.h
+++ b/src/engine/evaluation/nnue/perspective_accumulator.h
@@ -26,6 +26,15 @@ constexpr std::array<int, 64> kKingBucketMap {
 };
 // clang-format on
 
+[[nodiscard]] constexpr int HmcBucket(U16 fifty_moves_clock) {
+  if (fifty_moves_clock < arch::kHmcBucketsStart) {
+    return -1;
+  }
+  const int idx =
+      (fifty_moves_clock - arch::kHmcBucketsStart) / arch::kHmcBucketsStep;
+  return std::min<int>(idx, arch::kHmcBucketCount - 1);
+}
+
 constexpr U8 kBucketDivisor =
     (32 + arch::kOutputBucketCount - 1) / arch::kOutputBucketCount;
 

--- a/src/engine/evaluation/nnue/perspective_accumulator.h
+++ b/src/engine/evaluation/nnue/perspective_accumulator.h
@@ -26,13 +26,26 @@ constexpr std::array<int, 64> kKingBucketMap {
 };
 // clang-format on
 
-[[nodiscard]] constexpr int HmcBucket(U16 fifty_moves_clock) {
-  if (fifty_moves_clock < arch::kHmcBucketsStart) {
-    return -1;
+using HmcBucketTable = std::array<U8, 101>;
+
+constexpr HmcBucketTable GenerateHmcBucketTable() {
+  HmcBucketTable table{};
+  for (std::size_t clock = 0; clock < table.size(); ++clock) {
+    if (clock < arch::kHmcBucketsStart) {
+      table[clock] = arch::kHmcBucketCount;
+    } else {
+      const std::size_t idx =
+          (clock - arch::kHmcBucketsStart) / arch::kHmcBucketsStep;
+      table[clock] = static_cast<U8>(std::min(idx, arch::kHmcBucketCount - 1));
+    }
   }
-  const int idx =
-      (fifty_moves_clock - arch::kHmcBucketsStart) / arch::kHmcBucketsStep;
-  return std::min<int>(idx, arch::kHmcBucketCount - 1);
+  return table;
+}
+
+constexpr HmcBucketTable kHmcBucketTable = GenerateHmcBucketTable();
+
+[[nodiscard]] inline int GetHmcBucket(U16 fifty_moves_clock) {
+  return kHmcBucketTable[std::min<U16>(fifty_moves_clock, 100)];
 }
 
 constexpr U8 kBucketDivisor =

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -238,7 +238,7 @@ void Searcher::IterativeDeepening(Thread &thread) {
 
 #ifndef DATAGEN
   // Adjust based on proximity to a fifty-move-rule draw
-  // static_eval = static_eval * (220 - state.fifty_moves_clock) / 220;
+  static_eval = static_eval * (220 - state.fifty_moves_clock) / 220;
 #endif
 
   return static_eval;

--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -238,7 +238,7 @@ void Searcher::IterativeDeepening(Thread &thread) {
 
 #ifndef DATAGEN
   // Adjust based on proximity to a fifty-move-rule draw
-  static_eval = static_eval * (220 - state.fifty_moves_clock) / 220;
+  // static_eval = static_eval * (220 - state.fifty_moves_clock) / 220;
 #endif
 
   return static_eval;


### PR DESCRIPTION
20k Fixed Nodes
```
ELO    1.54 +- 1.17 (95%)
SPRT   N=20000 Threads=1 Hash=16MB
LLR    3.08 (-2.25, 2.89) [0.00, 3.00]
GAMES  N: 142280 W: 42474 L: 41845 D: 57961
PENTA  [3210, 16701, 30707, 17294, 3228]
```
https://furybench.com/test/7338/

STC
```
ELO    2.07 +- 1.63 (95%)
SPRT   10.0+0.10s Threads=1 Hash=16MB
LLR    2.90 (-2.25, 2.89) [0.00, 3.00]
GAMES  N: 46272 W: 11652 L: 11376 D: 23244
PENTA  [162, 5354, 11823, 5640, 157]
```
https://furybench.com/test/7339/

STC + Fortress Book
```
ELO    3.66 +- 1.93 (95%)
SPRT   10.0+0.10s Threads=1 Hash=16MB
LLR    2.96 (-2.25, 2.89) [0.00, 3.00]
GAMES  N: 10908 W: 1981 L: 1866 D: 7061
PENTA  [6, 384, 4572, 473, 19]
```
https://furybench.com/test/7348/

LTC
```
ELO    3.70 +- 2.40 (95%)
SPRT   40.0+0.40s Threads=1 Hash=128MB
LLR    2.91 (-2.25, 2.89) [0.00, 3.00]
GAMES  N: 19354 W: 4858 L: 4652 D: 9844
PENTA  [20, 2150, 5125, 2368, 14]
```
https://furybench.com/test/7342/

Integral's first novel neural network architecture patch!