### PR TITLE
Don't use atomic adds for tb_hits/nodes_searched

### DIFF
--- a/src/engine/search/search.cc
+++ b/src/engine/search/search.cc
@@ -401,7 +401,8 @@ Score Searcher::QuiescentSearch(Thread &thread,
         history.correction_history->GetContEntry(state, move);
     stack->history_score = history.GetMoveScore(state, move, stack);
 
-    thread.nodes_searched.fetch_add(1, std::memory_order_relaxed);
+    auto searched = thread.nodes_searched.load(std::memory_order_relaxed);
+    thread.nodes_searched.store(searched + 1, std::memory_order_relaxed);
 
     board.MakeMove(move);
     const Score score =
@@ -612,7 +613,8 @@ Score Searcher::PVSearch(Thread &thread,
         tt_flag = TranspositionTableEntry::kExact;
       }
 
-      thread.tb_hits.fetch_add(1, std::memory_order_relaxed);
+      auto tb_hits = thread.tb_hits.load(std::memory_order_relaxed);
+      thread.tb_hits.store(tb_hits + 1, std::memory_order_relaxed);
 
       if (tt_flag == TranspositionTableEntry::kExact ||
           tt_flag == TranspositionTableEntry::kUpperBound && score <= alpha ||


### PR DESCRIPTION
They are only modified from a single thread (the search thread)

Bench: 2108122