### PR TITLE
SMP tune for 20k iterations

### DIFF
--- a/src/engine/evaluation/evaluation.h
+++ b/src/engine/evaluation/evaluation.h
@@ -10,7 +10,7 @@ TUNABLE(kSeePawnScore, 105, 50, 150, false);
 TUNABLE(kSeeKnightScore, 373, 200, 400, false);
 TUNABLE(kSeeBishopScore, 387, 200, 400, false);
 TUNABLE(kSeeRookScore, 593, 400, 600, false);
-TUNABLE(kSeeQueenScore, 1232, 700, 1500, false);
+TUNABLE(kSeeQueenScore, 1231, 700, 1500, false);
 TUNABLE(kSeeKingScore, 0, 0, 0, true);  // Always 0
 TUNABLE(kSeeNoneScore, 0, 0, 0, true);  // Always 0
 

--- a/src/engine/evaluation/evaluation.h
+++ b/src/engine/evaluation/evaluation.h
@@ -7,10 +7,10 @@
 namespace eval {
 
 TUNABLE(kSeePawnScore, 105, 50, 150, false);
-TUNABLE(kSeeKnightScore, 375, 200, 400, false);
-TUNABLE(kSeeBishopScore, 388, 200, 400, false);
+TUNABLE(kSeeKnightScore, 373, 200, 400, false);
+TUNABLE(kSeeBishopScore, 387, 200, 400, false);
 TUNABLE(kSeeRookScore, 593, 400, 600, false);
-TUNABLE(kSeeQueenScore, 1237, 700, 1500, false);
+TUNABLE(kSeeQueenScore, 1232, 700, 1500, false);
 TUNABLE(kSeeKingScore, 0, 0, 0, true);  // Always 0
 TUNABLE(kSeeNoneScore, 0, 0, 0, true);  // Always 0
 

--- a/src/engine/evaluation/evaluation.h
+++ b/src/engine/evaluation/evaluation.h
@@ -6,11 +6,11 @@
 
 namespace eval {
 
-TUNABLE(kSeePawnScore, 111, 50, 150, false);
-TUNABLE(kSeeKnightScore, 368, 200, 400, false);
-TUNABLE(kSeeBishopScore, 393, 200, 400, false);
-TUNABLE(kSeeRookScore, 588, 400, 600, false);
-TUNABLE(kSeeQueenScore, 1232, 700, 1500, false);
+TUNABLE(kSeePawnScore, 105, 50, 150, false);
+TUNABLE(kSeeKnightScore, 375, 200, 400, false);
+TUNABLE(kSeeBishopScore, 388, 200, 400, false);
+TUNABLE(kSeeRookScore, 593, 400, 600, false);
+TUNABLE(kSeeQueenScore, 1237, 700, 1500, false);
 TUNABLE(kSeeKingScore, 0, 0, 0, true);  // Always 0
 TUNABLE(kSeeNoneScore, 0, 0, 0, true);  // Always 0
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -5,43 +5,43 @@
 
 namespace search {
 
-TUNABLE_STEP(kLmrQuietBase, 0.8079015956613906, 0.5, 2.0, false, 0.08);
-TUNABLE_STEP(kLmrQuietDiv, 2.0879792555907377, 0.5, 3.0, false, 0.08);
-TUNABLE_STEP(kLmrTactBase, -0.3560780424392481, -1.0, 0.5, false, 0.08);
-TUNABLE_STEP(kLmrTactDiv, 2.8577651171311933, 1.0, 4.0, false, 0.08);
+TUNABLE_STEP(kLmrQuietBase, 0.8008544368599553, 0.5, 2.0, false, 0.08);
+TUNABLE_STEP(kLmrQuietDiv, 2.0904841365109514, 0.5, 3.0, false, 0.08);
+TUNABLE_STEP(kLmrTactBase, -0.36540611838567605, -1.0, 0.5, false, 0.08);
+TUNABLE_STEP(kLmrTactDiv, 2.8466417892889955, 1.0, 4.0, false, 0.08);
 
 TUNABLE(kAspWindowDepth, 4, 2, 8, true);
 TUNABLE_STEP(kAspWindowDelta, 10, 1, 50, false, 1);
-TUNABLE_STEP(kAspWindowGrowth, 1.4129554553311214, 0.1, 2.0, false, 0.03);
-TUNABLE(kAspWindowScoreDiv, 16231, 8192, 32768, false);
-TUNABLE_STEP(kAspBetaLerpFactor, 0.4505472272357914, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kAspWindowGrowth, 1.4125521546512148, 0.1, 2.0, false, 0.03);
+TUNABLE(kAspWindowScoreDiv, 15954, 8192, 32768, false);
+TUNABLE_STEP(kAspBetaLerpFactor, 0.4497698475419262, 0.0, 1.0, false, 0.1);
 
-TUNABLE_STEP(kQsCutoffLerpFactor, 0.2932957054448457, 0.0, 1.0, false, 0.1);
-TUNABLE_STEP(kQsFailHighLerpFactor, 0.6300545749125233, 0.0, 1.0, false, 0.1);
-TUNABLE_STEP(kQsFutMargin, 183, 20, 300, false, 20);
+TUNABLE_STEP(kQsCutoffLerpFactor, 0.27196366541910993, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFailHighLerpFactor, 0.6322486926656458, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFutMargin, 186, 20, 300, false, 20);
 
 TUNABLE(kEvalHistUpdateMult, 60, 20, 100, false);
-TUNABLE(kEvalHistUpdateMin, 100, 5, 500, false);
-TUNABLE(kEvalHistUpdateMax, 132, 5, 500, false);
-TUNABLE_STEP(kEvalHistUpdateBias, 0, 0, 50, false, 5);
+TUNABLE(kEvalHistUpdateMin, 98, 5, 500, false);
+TUNABLE(kEvalHistUpdateMax, 125, 5, 500, false);
+TUNABLE_STEP(kEvalHistUpdateBias, 1, 0, 50, false, 5);
 
-TUNABLE_STEP(kHindsightDepthReduction, 4002, 2048, 6144, false, 512);
+TUNABLE_STEP(kHindsightDepthReduction, 4023, 2048, 6144, false, 512);
 
 TUNABLE(kRevFutDepth, 11, 4, 10, true);
-TUNABLE_STEP(kRevFutMargin, 52, 50, 150, false, 5);
-TUNABLE_STEP(kRevFutImprovingMargin, 94, 20, 150, false, 5);
-TUNABLE_STEP(kRevFutOppEasyCaptureMargin, 90, 20, 150, false, 5);
-TUNABLE_STEP(kRevFutOppWorseningMargin, 27, 5, 70, false, 4);
-TUNABLE_STEP(kRevFutMinMargin, 10, 5, 100, false, 10);
+TUNABLE_STEP(kRevFutMargin, 50, 50, 150, false, 5);
+TUNABLE_STEP(kRevFutImprovingMargin, 95, 20, 150, false, 5);
+TUNABLE_STEP(kRevFutOppEasyCaptureMargin, 89, 20, 150, false, 5);
+TUNABLE_STEP(kRevFutOppWorseningMargin, 28, 5, 70, false, 4);
+TUNABLE_STEP(kRevFutMinMargin, 9, 5, 100, false, 10);
 TUNABLE_STEP(kRevFutComplexityMargin, 10, 1, 64, false, 10);
-TUNABLE_STEP(kRevFutLerpFactor, 0.5379183246024984, 0.0, 1.0, false, 0.05);
-TUNABLE(kRevFutHistoryDiv, 596, 200, 800, false);
+TUNABLE_STEP(kRevFutLerpFactor, 0.5434916956888157, 0.0, 1.0, false, 0.05);
+TUNABLE(kRevFutHistoryDiv, 605, 200, 800, false);
 
 TUNABLE(kRazoringDepth, 4, 1, 8, true);
-TUNABLE_STEP(kRazoringMult, 386, 200, 600, false, 20);
+TUNABLE_STEP(kRazoringMult, 392, 200, 600, false, 20);
 TUNABLE_STEP(kRazoringNotImproving, 415, 200, 600, false, 20);
 
-TUNABLE_STEP(kNmpBetaBase, 151, 50, 200, false, 15);
+TUNABLE_STEP(kNmpBetaBase, 152, 50, 200, false, 15);
 TUNABLE_STEP(kNmpBetaMult, 7, 5, 50, false, 5);
 TUNABLE(kNmpRedBase, 4, 1, 5, true);
 TUNABLE(kNmpRedDiv, 3, 2, 8, true);
@@ -49,30 +49,30 @@ TUNABLE(kNmpEvalDiv, 171, 100, 300, false);
 
 TUNABLE(kIirDepth, 4, 2, 8, true);
 
-TUNABLE_STEP(kLmrDepthNonPvNode, 1213, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthHistQuiet, 1464, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthNotImproving, 1318, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthRoundingCutoff, 739, 512, 2048, false, 100);
+TUNABLE_STEP(kLmrDepthNonPvNode, 1230, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthHistQuiet, 1533, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthNotImproving, 1356, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthRoundingCutoff, 745, 512, 2048, false, 100);
 
-TUNABLE_STEP(kLmpBase, 5244, 1024, 10240, false, 256);
-TUNABLE_STEP(kLmpDepthMult, 1104, 512, 2048, false, 64);
-TUNABLE_STEP(kLmpDiv, 3019, 2048, 4608, false, 128);
+TUNABLE_STEP(kLmpBase, 5293, 1024, 10240, false, 256);
+TUNABLE_STEP(kLmpDepthMult, 1111, 512, 2048, false, 64);
+TUNABLE_STEP(kLmpDiv, 3015, 2048, 4608, false, 128);
 TUNABLE_STEP(kLmpImprovingDiv, 1991, 1024, 3584, false, 128);
 
 TUNABLE(kFutPruneDepth, 8, 6, 12, true);
-TUNABLE_STEP(kFutMarginBase, 136, 100, 250, false, 20);
+TUNABLE_STEP(kFutMarginBase, 132, 100, 250, false, 20);
 TUNABLE_STEP(kFutMarginMult, 83, 50, 200, false, 5);
 TUNABLE(kFutMarginHistDiv, 124, 32, 256, false);
 
-TUNABLE(kSeeQuietThresh, -26, -150, -5, false);
-TUNABLE(kSeeNoisyThresh, -95, -150, -5, false);
+TUNABLE(kSeeQuietThresh, -27, -150, -5, false);
+TUNABLE(kSeeNoisyThresh, -94, -150, -5, false);
 TUNABLE(kSeePruneHistDiv, 138, 50, 300, false);
 
 TUNABLE(kHistPruneDepth, 5, 3, 8, true);
-TUNABLE(kHistThreshBase, -238, -1000, 500, false);
-TUNABLE(kHistThreshMult, -2211, -3000, -500, false);
-TUNABLE(kCaptHistThreshBase, -482, -1000, 500, false);
-TUNABLE(kCaptHistThreshMult, -1720, -3000, -1000, false);
+TUNABLE(kHistThreshBase, -229, -1000, 500, false);
+TUNABLE(kHistThreshMult, -2192, -3000, -500, false);
+TUNABLE(kCaptHistThreshBase, -492, -1000, 500, false);
+TUNABLE(kCaptHistThreshMult, -1733, -3000, -1000, false);
 
 TUNABLE(kLmrHistDiv, 11680, 5000, 15000, true);
 TUNABLE(kLmrCaptHistDiv, 11008, 5000, 15000, true);
@@ -86,31 +86,31 @@ TUNABLE(kSeDepth, 5, 6, 12, true);
 TUNABLE_STEP(kSeDepthReduction, 7, 0, 30, false, 1);
 TUNABLE_STEP(kSeBetaMargin, 17, 0, 32, false, 1);
 TUNABLE_STEP(kSeDoubleMargin, 8, 0, 50, false, 1);
-TUNABLE_STEP(kSePvDoubleMargin, 128, 0, 300, false, 30);
-TUNABLE_STEP(kSeTripleMargin, 55, 20, 250, false, 10);
+TUNABLE_STEP(kSePvDoubleMargin, 137, 0, 300, false, 30);
+TUNABLE_STEP(kSeTripleMargin, 54, 20, 250, false, 10);
 TUNABLE_STEP(kSeDepthExtensionDepth, 13, 0, 20, false, 1);
 
-TUNABLE_STEP(kLmrNonPvNode, 676, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrWasPvNode, 1228, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrCutNode, 2175, 1024, 4096, false, 150);
-TUNABLE_STEP(kLmrGivesCheck, 939, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrHistQuiet, 698, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrHistCapture, 1243, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrNotImproving, 906, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrComplexity, 715, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrFirstKillerMove, 891, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrSecondKillerMove, 917, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrRoundingCutoff, 582, 512, 2048, false, 120);
+TUNABLE_STEP(kLmrNonPvNode, 627, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrWasPvNode, 1225, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrCutNode, 2212, 1024, 4096, false, 150);
+TUNABLE_STEP(kLmrGivesCheck, 927, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrHistQuiet, 710, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrHistCapture, 1202, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrNotImproving, 937, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrComplexity, 692, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrFirstKillerMove, 861, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrSecondKillerMove, 952, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrRoundingCutoff, 574, 512, 2048, false, 120);
 
 TUNABLE(kProbcutDepth, 5, 1, 10, true);
-TUNABLE(kProbcutBetaDelta, 213, 50, 300, false);
+TUNABLE(kProbcutBetaDelta, 216, 50, 300, false);
 
-TUNABLE_STEP(kHistoryBonusMargin, 44, 5, 120, false, 10);
+TUNABLE_STEP(kHistoryBonusMargin, 45, 5, 120, false, 10);
 
-TUNABLE_STEP(kPcmQuietHistoryWeight, 1059, 512, 2048, false, 128);
-TUNABLE_STEP(kPcmPawnHistoryWeight, 485, 64, 2048, false, 64);
+TUNABLE_STEP(kPcmQuietHistoryWeight, 1041, 512, 2048, false, 128);
+TUNABLE_STEP(kPcmPawnHistoryWeight, 498, 64, 2048, false, 64);
 
-TUNABLE_STEP(kMaterialScaleBase, 27258, 10000, 32768, false, 500);
+TUNABLE_STEP(kMaterialScaleBase, 27141, 10000, 32768, false, 500);
 
 }  // namespace search
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -5,27 +5,27 @@
 
 namespace search {
 
-TUNABLE_STEP(kLmrQuietBase, 0.8008544368599553, 0.5, 2.0, false, 0.08);
-TUNABLE_STEP(kLmrQuietDiv, 2.0904841365109514, 0.5, 3.0, false, 0.08);
-TUNABLE_STEP(kLmrTactBase, -0.36540611838567605, -1.0, 0.5, false, 0.08);
-TUNABLE_STEP(kLmrTactDiv, 2.8466417892889955, 1.0, 4.0, false, 0.08);
+TUNABLE_STEP(kLmrQuietBase, 0.8010139925504106, 0.5, 2.0, false, 0.08);
+TUNABLE_STEP(kLmrQuietDiv, 2.094174666596249, 0.5, 3.0, false, 0.08);
+TUNABLE_STEP(kLmrTactBase, -0.3678144681772606, -1.0, 0.5, false, 0.08);
+TUNABLE_STEP(kLmrTactDiv, 2.84359161051046, 1.0, 4.0, false, 0.08);
 
 TUNABLE(kAspWindowDepth, 4, 2, 8, true);
 TUNABLE_STEP(kAspWindowDelta, 10, 1, 50, false, 1);
-TUNABLE_STEP(kAspWindowGrowth, 1.4125521546512148, 0.1, 2.0, false, 0.03);
-TUNABLE(kAspWindowScoreDiv, 15954, 8192, 32768, false);
-TUNABLE_STEP(kAspBetaLerpFactor, 0.4497698475419262, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kAspWindowGrowth, 1.4121308397398828, 0.1, 2.0, false, 0.03);
+TUNABLE(kAspWindowScoreDiv, 16001, 8192, 32768, false);
+TUNABLE_STEP(kAspBetaLerpFactor, 0.4495672216959034, 0.0, 1.0, false, 0.1);
 
-TUNABLE_STEP(kQsCutoffLerpFactor, 0.27196366541910993, 0.0, 1.0, false, 0.1);
-TUNABLE_STEP(kQsFailHighLerpFactor, 0.6322486926656458, 0.0, 1.0, false, 0.1);
-TUNABLE_STEP(kQsFutMargin, 186, 20, 300, false, 20);
+TUNABLE_STEP(kQsCutoffLerpFactor, 0.2689526611425705, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFailHighLerpFactor, 0.6352580812382164, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFutMargin, 187, 20, 300, false, 20);
 
 TUNABLE(kEvalHistUpdateMult, 60, 20, 100, false);
-TUNABLE(kEvalHistUpdateMin, 98, 5, 500, false);
-TUNABLE(kEvalHistUpdateMax, 125, 5, 500, false);
+TUNABLE(kEvalHistUpdateMin, 97, 5, 500, false);
+TUNABLE(kEvalHistUpdateMax, 124, 5, 500, false);
 TUNABLE_STEP(kEvalHistUpdateBias, 1, 0, 50, false, 5);
 
-TUNABLE_STEP(kHindsightDepthReduction, 4023, 2048, 6144, false, 512);
+TUNABLE_STEP(kHindsightDepthReduction, 4003, 2048, 6144, false, 512);
 
 TUNABLE(kRevFutDepth, 11, 4, 10, true);
 TUNABLE_STEP(kRevFutMargin, 50, 50, 150, false, 5);
@@ -33,8 +33,8 @@ TUNABLE_STEP(kRevFutImprovingMargin, 95, 20, 150, false, 5);
 TUNABLE_STEP(kRevFutOppEasyCaptureMargin, 89, 20, 150, false, 5);
 TUNABLE_STEP(kRevFutOppWorseningMargin, 28, 5, 70, false, 4);
 TUNABLE_STEP(kRevFutMinMargin, 9, 5, 100, false, 10);
-TUNABLE_STEP(kRevFutComplexityMargin, 10, 1, 64, false, 10);
-TUNABLE_STEP(kRevFutLerpFactor, 0.5434916956888157, 0.0, 1.0, false, 0.05);
+TUNABLE_STEP(kRevFutComplexityMargin, 9, 1, 64, false, 10);
+TUNABLE_STEP(kRevFutLerpFactor, 0.5425908596819143, 0.0, 1.0, false, 0.05);
 TUNABLE(kRevFutHistoryDiv, 605, 200, 800, false);
 
 TUNABLE(kRazoringDepth, 4, 1, 8, true);
@@ -50,17 +50,17 @@ TUNABLE(kNmpEvalDiv, 171, 100, 300, false);
 TUNABLE(kIirDepth, 4, 2, 8, true);
 
 TUNABLE_STEP(kLmrDepthNonPvNode, 1230, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthHistQuiet, 1533, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthNotImproving, 1356, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthRoundingCutoff, 745, 512, 2048, false, 100);
+TUNABLE_STEP(kLmrDepthHistQuiet, 1532, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthNotImproving, 1352, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthRoundingCutoff, 743, 512, 2048, false, 100);
 
-TUNABLE_STEP(kLmpBase, 5293, 1024, 10240, false, 256);
-TUNABLE_STEP(kLmpDepthMult, 1111, 512, 2048, false, 64);
-TUNABLE_STEP(kLmpDiv, 3015, 2048, 4608, false, 128);
-TUNABLE_STEP(kLmpImprovingDiv, 1991, 1024, 3584, false, 128);
+TUNABLE_STEP(kLmpBase, 5300, 1024, 10240, false, 256);
+TUNABLE_STEP(kLmpDepthMult, 1113, 512, 2048, false, 64);
+TUNABLE_STEP(kLmpDiv, 3016, 2048, 4608, false, 128);
+TUNABLE_STEP(kLmpImprovingDiv, 1986, 1024, 3584, false, 128);
 
 TUNABLE(kFutPruneDepth, 8, 6, 12, true);
-TUNABLE_STEP(kFutMarginBase, 132, 100, 250, false, 20);
+TUNABLE_STEP(kFutMarginBase, 131, 100, 250, false, 20);
 TUNABLE_STEP(kFutMarginMult, 83, 50, 200, false, 5);
 TUNABLE(kFutMarginHistDiv, 124, 32, 256, false);
 
@@ -70,9 +70,9 @@ TUNABLE(kSeePruneHistDiv, 138, 50, 300, false);
 
 TUNABLE(kHistPruneDepth, 5, 3, 8, true);
 TUNABLE(kHistThreshBase, -229, -1000, 500, false);
-TUNABLE(kHistThreshMult, -2192, -3000, -500, false);
-TUNABLE(kCaptHistThreshBase, -492, -1000, 500, false);
-TUNABLE(kCaptHistThreshMult, -1733, -3000, -1000, false);
+TUNABLE(kHistThreshMult, -2191, -3000, -500, false);
+TUNABLE(kCaptHistThreshBase, -494, -1000, 500, false);
+TUNABLE(kCaptHistThreshMult, -1735, -3000, -1000, false);
 
 TUNABLE(kLmrHistDiv, 11680, 5000, 15000, true);
 TUNABLE(kLmrCaptHistDiv, 11008, 5000, 15000, true);
@@ -86,31 +86,31 @@ TUNABLE(kSeDepth, 5, 6, 12, true);
 TUNABLE_STEP(kSeDepthReduction, 7, 0, 30, false, 1);
 TUNABLE_STEP(kSeBetaMargin, 17, 0, 32, false, 1);
 TUNABLE_STEP(kSeDoubleMargin, 8, 0, 50, false, 1);
-TUNABLE_STEP(kSePvDoubleMargin, 137, 0, 300, false, 30);
-TUNABLE_STEP(kSeTripleMargin, 54, 20, 250, false, 10);
+TUNABLE_STEP(kSePvDoubleMargin, 136, 0, 300, false, 30);
+TUNABLE_STEP(kSeTripleMargin, 55, 20, 250, false, 10);
 TUNABLE_STEP(kSeDepthExtensionDepth, 13, 0, 20, false, 1);
 
-TUNABLE_STEP(kLmrNonPvNode, 627, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrWasPvNode, 1225, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrCutNode, 2212, 1024, 4096, false, 150);
-TUNABLE_STEP(kLmrGivesCheck, 927, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrHistQuiet, 710, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrHistCapture, 1202, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrNotImproving, 937, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrComplexity, 692, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrFirstKillerMove, 861, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrSecondKillerMove, 952, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrRoundingCutoff, 574, 512, 2048, false, 120);
+TUNABLE_STEP(kLmrNonPvNode, 623, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrWasPvNode, 1222, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrCutNode, 2216, 1024, 4096, false, 150);
+TUNABLE_STEP(kLmrGivesCheck, 928, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrHistQuiet, 712, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrHistCapture, 1195, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrNotImproving, 934, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrComplexity, 696, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrFirstKillerMove, 858, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrSecondKillerMove, 947, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrRoundingCutoff, 579, 512, 2048, false, 120);
 
 TUNABLE(kProbcutDepth, 5, 1, 10, true);
-TUNABLE(kProbcutBetaDelta, 216, 50, 300, false);
+TUNABLE(kProbcutBetaDelta, 215, 50, 300, false);
 
 TUNABLE_STEP(kHistoryBonusMargin, 45, 5, 120, false, 10);
 
-TUNABLE_STEP(kPcmQuietHistoryWeight, 1041, 512, 2048, false, 128);
-TUNABLE_STEP(kPcmPawnHistoryWeight, 498, 64, 2048, false, 64);
+TUNABLE_STEP(kPcmQuietHistoryWeight, 1047, 512, 2048, false, 128);
+TUNABLE_STEP(kPcmPawnHistoryWeight, 497, 64, 2048, false, 64);
 
-TUNABLE_STEP(kMaterialScaleBase, 27141, 10000, 32768, false, 500);
+TUNABLE_STEP(kMaterialScaleBase, 27120, 10000, 32768, false, 500);
 
 }  // namespace search
 

--- a/src/engine/search/constants.h
+++ b/src/engine/search/constants.h
@@ -5,112 +5,112 @@
 
 namespace search {
 
-TUNABLE_STEP(kLmrQuietBase, 0.7942757532398008, 0.5, 2.0, false, 0.08);
-TUNABLE_STEP(kLmrQuietDiv, 2.0711362345673554, 0.5, 3.0, false, 0.08);
-TUNABLE_STEP(kLmrTactBase, -0.3400543194068645, -1.0, 0.5, false, 0.08);
-TUNABLE_STEP(kLmrTactDiv, 2.8603688787714847, 1.0, 4.0, false, 0.08);
+TUNABLE_STEP(kLmrQuietBase, 0.8079015956613906, 0.5, 2.0, false, 0.08);
+TUNABLE_STEP(kLmrQuietDiv, 2.0879792555907377, 0.5, 3.0, false, 0.08);
+TUNABLE_STEP(kLmrTactBase, -0.3560780424392481, -1.0, 0.5, false, 0.08);
+TUNABLE_STEP(kLmrTactDiv, 2.8577651171311933, 1.0, 4.0, false, 0.08);
 
 TUNABLE(kAspWindowDepth, 4, 2, 8, true);
 TUNABLE_STEP(kAspWindowDelta, 10, 1, 50, false, 1);
-TUNABLE_STEP(kAspWindowGrowth, 1.3983208308938992, 0.1, 2.0, false, 0.03);
-TUNABLE(kAspWindowScoreDiv, 15954, 8192, 32768, false);
-TUNABLE_STEP(kAspBetaLerpFactor, 0.4935066776988994, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kAspWindowGrowth, 1.4129554553311214, 0.1, 2.0, false, 0.03);
+TUNABLE(kAspWindowScoreDiv, 16231, 8192, 32768, false);
+TUNABLE_STEP(kAspBetaLerpFactor, 0.4505472272357914, 0.0, 1.0, false, 0.1);
 
-TUNABLE_STEP(kQsCutoffLerpFactor, 0.2807830604772068, 0.0, 1.0, false, 0.1);
-TUNABLE_STEP(kQsFailHighLerpFactor, 0.5905119923701746, 0.0, 1.0, false, 0.1);
-TUNABLE_STEP(kQsFutMargin, 173, 20, 300, false, 20);
+TUNABLE_STEP(kQsCutoffLerpFactor, 0.2932957054448457, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFailHighLerpFactor, 0.6300545749125233, 0.0, 1.0, false, 0.1);
+TUNABLE_STEP(kQsFutMargin, 183, 20, 300, false, 20);
 
-TUNABLE(kEvalHistUpdateMult, 58, 20, 100, false);
-TUNABLE(kEvalHistUpdateMin, 68, 5, 500, false);
-TUNABLE(kEvalHistUpdateMax, 108, 5, 500, false);
-TUNABLE_STEP(kEvalHistUpdateBias, 1, 0, 50, false, 5);
+TUNABLE(kEvalHistUpdateMult, 60, 20, 100, false);
+TUNABLE(kEvalHistUpdateMin, 100, 5, 500, false);
+TUNABLE(kEvalHistUpdateMax, 132, 5, 500, false);
+TUNABLE_STEP(kEvalHistUpdateBias, 0, 0, 50, false, 5);
 
-TUNABLE_STEP(kHindsightDepthReduction, 4096, 2048, 6144, false, 512);
+TUNABLE_STEP(kHindsightDepthReduction, 4002, 2048, 6144, false, 512);
 
 TUNABLE(kRevFutDepth, 11, 4, 10, true);
-TUNABLE_STEP(kRevFutMargin, 50, 50, 150, false, 5);
+TUNABLE_STEP(kRevFutMargin, 52, 50, 150, false, 5);
 TUNABLE_STEP(kRevFutImprovingMargin, 94, 20, 150, false, 5);
-TUNABLE_STEP(kRevFutOppEasyCaptureMargin, 94, 20, 150, false, 5);
-TUNABLE_STEP(kRevFutOppWorseningMargin, 25, 5, 70, false, 4);
-TUNABLE_STEP(kRevFutMinMargin, 13, 5, 100, false, 10);
-TUNABLE_STEP(kRevFutComplexityMargin, 12, 1, 64, false, 10);
-TUNABLE_STEP(kRevFutLerpFactor, 0.5160669355461122, 0.0, 1.0, false, 0.05);
-TUNABLE(kRevFutHistoryDiv, 586, 200, 800, false);
+TUNABLE_STEP(kRevFutOppEasyCaptureMargin, 90, 20, 150, false, 5);
+TUNABLE_STEP(kRevFutOppWorseningMargin, 27, 5, 70, false, 4);
+TUNABLE_STEP(kRevFutMinMargin, 10, 5, 100, false, 10);
+TUNABLE_STEP(kRevFutComplexityMargin, 10, 1, 64, false, 10);
+TUNABLE_STEP(kRevFutLerpFactor, 0.5379183246024984, 0.0, 1.0, false, 0.05);
+TUNABLE(kRevFutHistoryDiv, 596, 200, 800, false);
 
 TUNABLE(kRazoringDepth, 4, 1, 8, true);
-TUNABLE_STEP(kRazoringMult, 393, 200, 600, false, 20);
-TUNABLE_STEP(kRazoringNotImproving, 393, 200, 600, false, 20);
+TUNABLE_STEP(kRazoringMult, 386, 200, 600, false, 20);
+TUNABLE_STEP(kRazoringNotImproving, 415, 200, 600, false, 20);
 
-TUNABLE_STEP(kNmpBetaBase, 146, 50, 200, false, 15);
+TUNABLE_STEP(kNmpBetaBase, 151, 50, 200, false, 15);
 TUNABLE_STEP(kNmpBetaMult, 7, 5, 50, false, 5);
 TUNABLE(kNmpRedBase, 4, 1, 5, true);
 TUNABLE(kNmpRedDiv, 3, 2, 8, true);
-TUNABLE(kNmpEvalDiv, 169, 100, 300, false);
+TUNABLE(kNmpEvalDiv, 171, 100, 300, false);
 
 TUNABLE(kIirDepth, 4, 2, 8, true);
 
-TUNABLE_STEP(kLmrDepthNonPvNode, 1265, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthHistQuiet, 1374, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthNotImproving, 1302, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrDepthRoundingCutoff, 675, 512, 2048, false, 100);
+TUNABLE_STEP(kLmrDepthNonPvNode, 1213, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthHistQuiet, 1464, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthNotImproving, 1318, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrDepthRoundingCutoff, 739, 512, 2048, false, 100);
 
-TUNABLE_STEP(kLmpBase, 5120, 1024, 10240, false, 256);
-TUNABLE_STEP(kLmpDepthMult, 1024, 512, 2048, false, 64);
-TUNABLE_STEP(kLmpDiv, 3072, 2048, 4608, false, 128);
-TUNABLE_STEP(kLmpImprovingDiv, 2048, 1024, 3584, false, 128);
+TUNABLE_STEP(kLmpBase, 5244, 1024, 10240, false, 256);
+TUNABLE_STEP(kLmpDepthMult, 1104, 512, 2048, false, 64);
+TUNABLE_STEP(kLmpDiv, 3019, 2048, 4608, false, 128);
+TUNABLE_STEP(kLmpImprovingDiv, 1991, 1024, 3584, false, 128);
 
 TUNABLE(kFutPruneDepth, 8, 6, 12, true);
-TUNABLE_STEP(kFutMarginBase, 128, 100, 250, false, 20);
-TUNABLE_STEP(kFutMarginMult, 81, 50, 200, false, 5);
+TUNABLE_STEP(kFutMarginBase, 136, 100, 250, false, 20);
+TUNABLE_STEP(kFutMarginMult, 83, 50, 200, false, 5);
 TUNABLE(kFutMarginHistDiv, 124, 32, 256, false);
 
-TUNABLE(kSeeQuietThresh, -17, -150, -5, false);
-TUNABLE(kSeeNoisyThresh, -98, -150, -5, false);
-TUNABLE(kSeePruneHistDiv, 131, 50, 300, false);
+TUNABLE(kSeeQuietThresh, -26, -150, -5, false);
+TUNABLE(kSeeNoisyThresh, -95, -150, -5, false);
+TUNABLE(kSeePruneHistDiv, 138, 50, 300, false);
 
 TUNABLE(kHistPruneDepth, 5, 3, 8, true);
-TUNABLE(kHistThreshBase, -250, -1000, 500, false);
-TUNABLE(kHistThreshMult, -2198, -3000, -500, false);
-TUNABLE(kCaptHistThreshBase, -447, -1000, 500, false);
-TUNABLE(kCaptHistThreshMult, -1773, -3000, -1000, false);
+TUNABLE(kHistThreshBase, -238, -1000, 500, false);
+TUNABLE(kHistThreshMult, -2211, -3000, -500, false);
+TUNABLE(kCaptHistThreshBase, -482, -1000, 500, false);
+TUNABLE(kCaptHistThreshMult, -1720, -3000, -1000, false);
 
 TUNABLE(kLmrHistDiv, 11680, 5000, 15000, true);
 TUNABLE(kLmrCaptHistDiv, 11008, 5000, 15000, true);
-TUNABLE(kLmrComplexityDiff, 73, 5, 150, false);
+TUNABLE(kLmrComplexityDiff, 70, 5, 150, false);
 
-TUNABLE(kDoDeeperBase, 30, 10, 60, false);
+TUNABLE(kDoDeeperBase, 29, 10, 60, false);
 TUNABLE(kDoDeeperMult, 33, 16, 64, false);
-TUNABLE(kDoShallowerBase, 5, 0, 50, false);
+TUNABLE(kDoShallowerBase, 6, 0, 50, false);
 
 TUNABLE(kSeDepth, 5, 6, 12, true);
 TUNABLE_STEP(kSeDepthReduction, 7, 0, 30, false, 1);
 TUNABLE_STEP(kSeBetaMargin, 17, 0, 32, false, 1);
 TUNABLE_STEP(kSeDoubleMargin, 8, 0, 50, false, 1);
-TUNABLE_STEP(kSePvDoubleMargin, 150, 0, 300, false, 30);
-TUNABLE_STEP(kSeTripleMargin, 58, 20, 250, false, 10);
+TUNABLE_STEP(kSePvDoubleMargin, 128, 0, 300, false, 30);
+TUNABLE_STEP(kSeTripleMargin, 55, 20, 250, false, 10);
 TUNABLE_STEP(kSeDepthExtensionDepth, 13, 0, 20, false, 1);
 
-TUNABLE_STEP(kLmrNonPvNode, 743, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrWasPvNode, 1168, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrCutNode, 2205, 1024, 4096, false, 150);
-TUNABLE_STEP(kLmrGivesCheck, 942, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrHistQuiet, 522, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrHistCapture, 1229, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrNotImproving, 949, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrComplexity, 778, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrFirstKillerMove, 886, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrSecondKillerMove, 886, 512, 2048, false, 150);
-TUNABLE_STEP(kLmrRoundingCutoff, 698, 512, 2048, false, 120);
+TUNABLE_STEP(kLmrNonPvNode, 676, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrWasPvNode, 1228, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrCutNode, 2175, 1024, 4096, false, 150);
+TUNABLE_STEP(kLmrGivesCheck, 939, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrHistQuiet, 698, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrHistCapture, 1243, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrNotImproving, 906, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrComplexity, 715, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrFirstKillerMove, 891, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrSecondKillerMove, 917, 512, 2048, false, 150);
+TUNABLE_STEP(kLmrRoundingCutoff, 582, 512, 2048, false, 120);
 
 TUNABLE(kProbcutDepth, 5, 1, 10, true);
 TUNABLE(kProbcutBetaDelta, 213, 50, 300, false);
 
 TUNABLE_STEP(kHistoryBonusMargin, 44, 5, 120, false, 10);
 
-TUNABLE_STEP(kPcmQuietHistoryWeight, 1024, 512, 2048, false, 128);
-TUNABLE_STEP(kPcmPawnHistoryWeight, 512, 64, 2048, false, 64);
+TUNABLE_STEP(kPcmQuietHistoryWeight, 1059, 512, 2048, false, 128);
+TUNABLE_STEP(kPcmPawnHistoryWeight, 485, 64, 2048, false, 64);
 
-TUNABLE_STEP(kMaterialScaleBase, 27600, 10000, 32768, false, 500);
+TUNABLE_STEP(kMaterialScaleBase, 27258, 10000, 32768, false, 500);
 
 }  // namespace search
 

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -6,11 +6,11 @@
 
 namespace search::history {
 
-TUNABLE(kHistBonusGravity, 12428, 8192, 32768, false);
+TUNABLE(kHistBonusGravity, 12411, 8192, 32768, false);
 TUNABLE(kHistBonusScale, 177, 65, 300, false);
 TUNABLE(kHistPenaltyScale, 158, 65, 300, false);
 TUNABLE_STEP(kHistBonusMaxBonus, 1429, 580, 2500, false, 200);
-TUNABLE(kHistBonusBias, 137, 0, 300, false);
+TUNABLE(kHistBonusBias, 136, 0, 300, false);
 
 static I16 HistoryBonus(I16 depth,
                         I16 scale = kHistBonusScale,

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -6,11 +6,11 @@
 
 namespace search::history {
 
-TUNABLE(kHistBonusGravity, 12370, 8192, 32768, false);
-TUNABLE(kHistBonusScale, 176, 65, 300, false);
+TUNABLE(kHistBonusGravity, 12428, 8192, 32768, false);
+TUNABLE(kHistBonusScale, 177, 65, 300, false);
 TUNABLE(kHistPenaltyScale, 158, 65, 300, false);
-TUNABLE_STEP(kHistBonusMaxBonus, 1479, 580, 2500, false, 200);
-TUNABLE(kHistBonusBias, 130, 0, 300, false);
+TUNABLE_STEP(kHistBonusMaxBonus, 1429, 580, 2500, false, 200);
+TUNABLE(kHistBonusBias, 137, 0, 300, false);
 
 static I16 HistoryBonus(I16 depth,
                         I16 scale = kHistBonusScale,

--- a/src/engine/search/history/bonus.h
+++ b/src/engine/search/history/bonus.h
@@ -6,11 +6,11 @@
 
 namespace search::history {
 
-TUNABLE(kHistBonusGravity, 11422, 8192, 32768, false);
-TUNABLE(kHistBonusScale, 168, 65, 300, false);
-TUNABLE(kHistPenaltyScale, 156, 65, 300, false);
-TUNABLE_STEP(kHistBonusMaxBonus, 1294, 580, 2500, false, 200);
-TUNABLE(kHistBonusBias, 126, 0, 300, false);
+TUNABLE(kHistBonusGravity, 12370, 8192, 32768, false);
+TUNABLE(kHistBonusScale, 176, 65, 300, false);
+TUNABLE(kHistPenaltyScale, 158, 65, 300, false);
+TUNABLE_STEP(kHistBonusMaxBonus, 1479, 580, 2500, false, 200);
+TUNABLE(kHistBonusBias, 130, 0, 300, false);
 
 static I16 HistoryBonus(I16 depth,
                         I16 scale = kHistBonusScale,

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -11,7 +11,7 @@
 
 namespace search::history {
 
-TUNABLE_STEP(kPawnCorrectionWeight, 44, 0, 125, false, 3);
+TUNABLE_STEP(kPawnCorrectionWeight, 45, 0, 125, false, 3);
 TUNABLE_STEP(kNonPawnCorrectionWeight, 42, 0, 125, false, 3);
 TUNABLE_STEP(kMajorCorrectionWeight, 37, 0, 125, false, 3);
 TUNABLE_STEP(kContinuationCorrectionWeight, 53, 0, 125, false, 3);

--- a/src/engine/search/history/correction_history.h
+++ b/src/engine/search/history/correction_history.h
@@ -11,10 +11,10 @@
 
 namespace search::history {
 
-TUNABLE_STEP(kPawnCorrectionWeight, 42, 0, 125, false, 3);
-TUNABLE_STEP(kNonPawnCorrectionWeight, 40, 0, 125, false, 3);
+TUNABLE_STEP(kPawnCorrectionWeight, 44, 0, 125, false, 3);
+TUNABLE_STEP(kNonPawnCorrectionWeight, 42, 0, 125, false, 3);
 TUNABLE_STEP(kMajorCorrectionWeight, 37, 0, 125, false, 3);
-TUNABLE_STEP(kContinuationCorrectionWeight, 52, 0, 125, false, 3);
+TUNABLE_STEP(kContinuationCorrectionWeight, 53, 0, 125, false, 3);
 
 class CorrectionHistory {
   constexpr static U16 kDefaultHashSize = 16384;

--- a/src/engine/search/history/history.h
+++ b/src/engine/search/history/history.h
@@ -10,11 +10,11 @@
 
 namespace search::history {
 
-TUNABLE(kQuietHistoryWeight, 1055, 0, 2048, false);
-TUNABLE(kFirstContinuationHistoryWeight, 1275, 0, 2048, false);
-TUNABLE(kSecondContinuationHistoryWeight, 974, 0, 2048, false);
-TUNABLE(kFourthContinuationHistoryWeight, 910, 0, 2048, false);
-TUNABLE(kPawnHistoryWeight, 1036, 0, 2048, false);
+TUNABLE(kQuietHistoryWeight, 1049, 0, 2048, false);
+TUNABLE(kFirstContinuationHistoryWeight, 1317, 0, 2048, false);
+TUNABLE(kSecondContinuationHistoryWeight, 1093, 0, 2048, false);
+TUNABLE(kFourthContinuationHistoryWeight, 995, 0, 2048, false);
+TUNABLE(kPawnHistoryWeight, 1084, 0, 2048, false);
 
 constexpr int kHistoryWeightScale = 1024;
 

--- a/src/engine/search/history/history.h
+++ b/src/engine/search/history/history.h
@@ -10,11 +10,11 @@
 
 namespace search::history {
 
-TUNABLE(kQuietHistoryWeight, 1049, 0, 2048, false);
+TUNABLE(kQuietHistoryWeight, 1074, 0, 2048, false);
 TUNABLE(kFirstContinuationHistoryWeight, 1317, 0, 2048, false);
-TUNABLE(kSecondContinuationHistoryWeight, 1093, 0, 2048, false);
-TUNABLE(kFourthContinuationHistoryWeight, 995, 0, 2048, false);
-TUNABLE(kPawnHistoryWeight, 1084, 0, 2048, false);
+TUNABLE(kSecondContinuationHistoryWeight, 1109, 0, 2048, false);
+TUNABLE(kFourthContinuationHistoryWeight, 1006, 0, 2048, false);
+TUNABLE(kPawnHistoryWeight, 1091, 0, 2048, false);
 
 constexpr int kHistoryWeightScale = 1024;
 

--- a/src/engine/search/history/history.h
+++ b/src/engine/search/history/history.h
@@ -10,11 +10,11 @@
 
 namespace search::history {
 
-TUNABLE(kQuietHistoryWeight, 1074, 0, 2048, false);
-TUNABLE(kFirstContinuationHistoryWeight, 1317, 0, 2048, false);
-TUNABLE(kSecondContinuationHistoryWeight, 1109, 0, 2048, false);
-TUNABLE(kFourthContinuationHistoryWeight, 1006, 0, 2048, false);
-TUNABLE(kPawnHistoryWeight, 1091, 0, 2048, false);
+TUNABLE(kQuietHistoryWeight, 1076, 0, 2048, false);
+TUNABLE(kFirstContinuationHistoryWeight, 1321, 0, 2048, false);
+TUNABLE(kSecondContinuationHistoryWeight, 1110, 0, 2048, false);
+TUNABLE(kFourthContinuationHistoryWeight, 1009, 0, 2048, false);
+TUNABLE(kPawnHistoryWeight, 1089, 0, 2048, false);
 
 constexpr int kHistoryWeightScale = 1024;
 

--- a/src/engine/search/history/pawn_history.h
+++ b/src/engine/search/history/pawn_history.h
@@ -7,7 +7,7 @@
 
 namespace search::history {
 
-TUNABLE(kPawnHistFill, -970, -3000, 0, false);
+TUNABLE(kPawnHistFill, -967, -3000, 0, false);
 
 class PawnHistory {
  public:

--- a/src/engine/search/history/pawn_history.h
+++ b/src/engine/search/history/pawn_history.h
@@ -7,7 +7,7 @@
 
 namespace search::history {
 
-TUNABLE(kPawnHistFill, -951, -3000, 0, false);
+TUNABLE(kPawnHistFill, -970, -3000, 0, false);
 
 class PawnHistory {
  public:

--- a/src/engine/search/history/pawn_history.h
+++ b/src/engine/search/history/pawn_history.h
@@ -7,7 +7,7 @@
 
 namespace search::history {
 
-TUNABLE(kPawnHistFill, -919, -3000, 0, false);
+TUNABLE(kPawnHistFill, -951, -3000, 0, false);
 
 class PawnHistory {
  public:

--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -4,11 +4,11 @@ namespace search {
 
 TUNABLE(kSeeNoisyHistoryDiv, 86, 32, 250, false);
 
-TUNABLE(kPawnScore, 102, 50, 150, false);
-TUNABLE(kKnightScore, 297, 200, 400, false);
+TUNABLE(kPawnScore, 103, 50, 150, false);
+TUNABLE(kKnightScore, 299, 200, 400, false);
 TUNABLE(kBishopScore, 278, 200, 400, false);
-TUNABLE(kRookScore, 526, 400, 600, false);
-TUNABLE(kQueenScore, 887, 700, 1100, false);
+TUNABLE(kRookScore, 524, 400, 600, false);
+TUNABLE(kQueenScore, 886, 700, 1100, false);
 TUNABLE(kKingScore, 0, 0, 0, true);  // Always 0
 TUNABLE(kNoneScore, 0, 0, 0, true);  // Always 0
 
@@ -24,14 +24,14 @@ inline std::array kPieceScores = {
 };
 // clang-format on
 
-TUNABLE(kQueenRookThreatScorePos, 19816, 10000, 30000, false);
-TUNABLE(kQueenRookThreatScoreNeg, 17331, 10000, 30000, false);
-TUNABLE(kRookMinorThreatScorePos, 13655, 5000, 20000, false);
-TUNABLE(kRookMinorThreatScoreNeg, 13396, 5000, 20000, false);
-TUNABLE(kMinorPawnThreatScorePos, 8088, 3000, 12000, false);
-TUNABLE(kMinorPawnThreatScoreNeg, 8499, 3000, 12000, false);
+TUNABLE(kQueenRookThreatScorePos, 19766, 10000, 30000, false);
+TUNABLE(kQueenRookThreatScoreNeg, 17219, 10000, 30000, false);
+TUNABLE(kRookMinorThreatScorePos, 13683, 5000, 20000, false);
+TUNABLE(kRookMinorThreatScoreNeg, 13437, 5000, 20000, false);
+TUNABLE(kMinorPawnThreatScorePos, 8053, 3000, 12000, false);
+TUNABLE(kMinorPawnThreatScoreNeg, 8674, 3000, 12000, false);
 
-TUNABLE(kDirectCheckBonus, 1995, 512, 6144, false);
+TUNABLE(kDirectCheckBonus, 2043, 512, 6144, false);
 
 MovePicker::MovePicker(MovePickerType type,
                        Board &board,

--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -4,7 +4,7 @@ namespace search {
 
 TUNABLE(kSeeNoisyHistoryDiv, 86, 32, 250, false);
 
-TUNABLE(kPawnScore, 103, 50, 150, false);
+TUNABLE(kPawnScore, 104, 50, 150, false);
 TUNABLE(kKnightScore, 299, 200, 400, false);
 TUNABLE(kBishopScore, 278, 200, 400, false);
 TUNABLE(kRookScore, 524, 400, 600, false);
@@ -24,14 +24,14 @@ inline std::array kPieceScores = {
 };
 // clang-format on
 
-TUNABLE(kQueenRookThreatScorePos, 19766, 10000, 30000, false);
-TUNABLE(kQueenRookThreatScoreNeg, 17219, 10000, 30000, false);
-TUNABLE(kRookMinorThreatScorePos, 13683, 5000, 20000, false);
-TUNABLE(kRookMinorThreatScoreNeg, 13437, 5000, 20000, false);
-TUNABLE(kMinorPawnThreatScorePos, 8053, 3000, 12000, false);
-TUNABLE(kMinorPawnThreatScoreNeg, 8674, 3000, 12000, false);
+TUNABLE(kQueenRookThreatScorePos, 19784, 10000, 30000, false);
+TUNABLE(kQueenRookThreatScoreNeg, 17201, 10000, 30000, false);
+TUNABLE(kRookMinorThreatScorePos, 13682, 5000, 20000, false);
+TUNABLE(kRookMinorThreatScoreNeg, 13432, 5000, 20000, false);
+TUNABLE(kMinorPawnThreatScorePos, 8031, 3000, 12000, false);
+TUNABLE(kMinorPawnThreatScoreNeg, 8670, 3000, 12000, false);
 
-TUNABLE(kDirectCheckBonus, 2043, 512, 6144, false);
+TUNABLE(kDirectCheckBonus, 2044, 512, 6144, false);
 
 MovePicker::MovePicker(MovePickerType type,
                        Board &board,

--- a/src/engine/search/move_picker.cc
+++ b/src/engine/search/move_picker.cc
@@ -2,13 +2,13 @@
 
 namespace search {
 
-TUNABLE(kSeeNoisyHistoryDiv, 92, 32, 250, false);
+TUNABLE(kSeeNoisyHistoryDiv, 86, 32, 250, false);
 
 TUNABLE(kPawnScore, 102, 50, 150, false);
-TUNABLE(kKnightScore, 301, 200, 400, false);
-TUNABLE(kBishopScore, 281, 200, 400, false);
-TUNABLE(kRookScore, 523, 400, 600, false);
-TUNABLE(kQueenScore, 889, 700, 1100, false);
+TUNABLE(kKnightScore, 297, 200, 400, false);
+TUNABLE(kBishopScore, 278, 200, 400, false);
+TUNABLE(kRookScore, 526, 400, 600, false);
+TUNABLE(kQueenScore, 887, 700, 1100, false);
 TUNABLE(kKingScore, 0, 0, 0, true);  // Always 0
 TUNABLE(kNoneScore, 0, 0, 0, true);  // Always 0
 
@@ -24,14 +24,14 @@ inline std::array kPieceScores = {
 };
 // clang-format on
 
-TUNABLE(kQueenRookThreatScorePos, 19451, 10000, 30000, false);
-TUNABLE(kQueenRookThreatScoreNeg, 17612, 10000, 30000, false);
-TUNABLE(kRookMinorThreatScorePos, 13177, 5000, 20000, false);
-TUNABLE(kRookMinorThreatScoreNeg, 13758, 5000, 20000, false);
-TUNABLE(kMinorPawnThreatScorePos, 7852, 3000, 12000, false);
-TUNABLE(kMinorPawnThreatScoreNeg, 8475, 3000, 12000, false);
+TUNABLE(kQueenRookThreatScorePos, 19816, 10000, 30000, false);
+TUNABLE(kQueenRookThreatScoreNeg, 17331, 10000, 30000, false);
+TUNABLE(kRookMinorThreatScorePos, 13655, 5000, 20000, false);
+TUNABLE(kRookMinorThreatScoreNeg, 13396, 5000, 20000, false);
+TUNABLE(kMinorPawnThreatScorePos, 8088, 3000, 12000, false);
+TUNABLE(kMinorPawnThreatScoreNeg, 8499, 3000, 12000, false);
 
-TUNABLE(kDirectCheckBonus, 2048, 512, 6144, false);
+TUNABLE(kDirectCheckBonus, 1995, 512, 6144, false);
 
 MovePicker::MovePicker(MovePickerType type,
                        Board &board,


### PR DESCRIPTION
```
ELO    5.64 +- 3.45 (95%)
SPRT   20.0+0.20s Threads=4 Hash=256MB
LLR    2.90 (-2.25, 2.89) [0.00, 4.00]
GAMES  N: 8928 W: 2349 L: 2204 D: 4375
PENTA  [3, 937, 2439, 1082, 3]
```
https://furybench.com/test/7388/